### PR TITLE
[BM-97] 테스트 및 테스트 커버리지 리포트 자동화 CI 입니다

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,35 @@
+name: Jacoco Code Coverage
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+    branches:
+      - 'develop'
+      - 'main'
+
+jobs:
+  code-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew build jacocoTestReport
+
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.12.RELEASE'
     id 'org.asciidoctor.convert' version '1.5.8'
     id 'java'
+    id 'jacoco'
 }
 
 group = 'com.saiko'
@@ -17,6 +18,10 @@ ext {
     set('snippetsDir', file("build/generated-snippets"))
 }
 
+jacoco {
+    toolVersion = '0.8.8'
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -26,9 +31,20 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+jacocoTestReport {
+    executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+    }
 }


### PR DESCRIPTION
- 테스트 및 테스트 커버리지 리포트 자동화 CI 입니다
- 아래와 같이 테스트 코드가 추가되는 경우 테스트 커버리지를 측정한 codecov 코멘트가 달리게 됩니다.
- [CodecovTest.java](https://github.com/prgrms-web-devcourse/Team-Saiko-BidMarket-BE/pull/1/files#diff-f2dc2552200982fcde5ea414cf46f5622dc1e3f59019e75e11d1adef4dbcedb0) 파일은 샘플파일이며 merge직전 삭제할 예정입니다.
- PR이름, 브랜치 이름은 스프린트가 시작하면 변경하도록 하겠습니다. [티켓번호] 테스트 및 테스트 커버리지 리포트 자동화 CI