### PR TITLE
[BM-61] OAuth2 인증관련 의존성 및 환경변수 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'com.auth0:java-jwt:3.19.2'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,9 @@
-
+spring:
+  security:
+    oauth2.client:
+      registration:
+        google:
+          clientId: '{google client-id}'
+          clientSecret: '{google client-secret}'
+          scope:
+            - profile


### PR DESCRIPTION
- 구글 OAuth 클라이언트 생성하였고, 클라이언트 id, secret key 는 Repository secrets에 등록해 두었습니다.
- security, oauth-client, auth0 및 인자 검증(isNotEmpty(), isNotBlank(), ...)을 위한 apach common lang 의존성을 추가하였습니다.