### PR TITLE
[BM-99] 소나 큐브 정적 분석 CI 적용

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,24 @@
+name: Sonarqube
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+    branches:
+      - 'develop'
+      - 'main'
+
+jobs:
+  sonarqube:
+    runs-on: [self-hosted]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: analysis
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./gradle -Pprofile=ci sonarqube -x test
+          -Dsonar.github.pullRequest=${{ env.PR_NUMBER }}
+          -Dsonar.github.oauth=${{ secrets.SONAR_ACCESS_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -9,7 +9,7 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     env:
-      SONARQUBE_ID: test-pr
+      SONARQUBE_ID: BidMarket-pr
       SONARQUBE_URL: ${{ secrets.SONARQUBE_URL }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,34 +2,35 @@ name: Sonarqube
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
-  build:
-
-    runs-on: [ self-hosted ]
-
+  analysis:
+    runs-on: ubuntu-latest
+    env:
+      SONARQUBE_ID: test-pr
+      SONARQUBE_URL: ${{ secrets.SONARQUBE_URL }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Sonaqube Analysis
+        run: ./gradlew test sonarqube
+          -Dsonar.host.url=${{ env.SONARQUBE_URL }}
+          -Dsonar.projectKey=${{ env.SONARQUBE_ID }}
+          -Dsonar.projectName=${{ env.SONARQUBE_ID }}-${{ env.PR_NUMBER }}
+          -Dsonar.login=squ_e4012a0e9428914394dccbd9757579bab4c7f183
+
+      - name: Comment Sonarqube URL
+        uses: actions/github-script@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew clean test
-
-  sonarqube:
-
-    runs-on: [ self-hosted ]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: analysis
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: ./gradlew -Pprofile=ci sonarqube -x test
-        -Dsonar.github.pullRequests=${{ env.PR_NUMBER }}
-        -Dsonar.github.oauth=${{ secret.SONAR_ACCESS_TOKEN }}
+          script: |
+            const { SONARQUBE_ID, SONARQUBE_URL, PR_NUMBER } = process.env
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📊 ${ SONARQUBE_ID }-${ PR_NUMBER } 분석 결과 확인 [링크](${SONARQUBE_URL})`
+            })

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,24 +1,35 @@
 name: Sonarqube
 
 on:
-  push:
-    branches:
-      - 'develop'
-      - 'main'
   pull_request:
-    branches:
-      - 'develop'
-      - 'main'
+    branches: [ main ]
 
 jobs:
-  sonarqube:
-    runs-on: [self-hosted]
+  build:
+
+    runs-on: [ self-hosted ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew clean test
+
+  sonarqube:
+
+    runs-on: [ self-hosted ]
+
+    steps:
+      - uses: actions/checkout@v2
       - name: analysis
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: ./gradle -Pprofile=ci sonarqube -x test
-          -Dsonar.github.pullRequest=${{ env.PR_NUMBER }}
-          -Dsonar.github.oauth=${{ secrets.SONAR_ACCESS_TOKEN }}
+        run: ./gradlew -Pprofile=ci sonarqube -x test
+        -Dsonar.github.pullRequests=${{ env.PR_NUMBER }}
+        -Dsonar.github.oauth=${{ secret.SONAR_ACCESS_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.8'
     id 'java'
     id 'jacoco'
+    id 'org.sonarqube' version '3.0'
 }
 
 group = 'com.saiko'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ sonarqube {
     properties {
         property 'sonar.host.url', 'http://3.39.218.101:80'
         property 'sonar.login', 'squ_e4012a0e9428914394dccbd9757579bab4c7f183'
-        property 'sonar.exclusions', 'src/test/java, **/*Test*.*'
         property 'sonar.github.endpoint', 'https://api.github.com'
         property 'sonar.github.repositroy', 'prgrms-web-devcourse/Team-Saiko-BidMarket-BE'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,12 @@ tasks.named('asciidoctor') {
     dependsOn test
 }
 
-jacocoTestReport {
-    executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
-
-    reports {
-        html.enabled true
-        xml.enabled true
-        csv.enabled false
+sonarqube {
+    properties {
+        property 'sonar.host.url', 'http://3.39.218.101:80'
+        property 'sonar.login', 'squ_e4012a0e9428914394dccbd9757579bab4c7f183'
+        property 'sonar.exclusions', 'src/test/java, **/*Test*.*'
+        property 'sonar.github.endpoint', 'https://api.github.com'
+        property 'sonar.github.repositroy', 'prgrms-web-devcourse/Team-Saiko-BidMarket-BE'
     }
 }


### PR DESCRIPTION
우선 적용하고 싶었던 기능은 소나 큐브 분석 결과를 해당 PR에 comment가 달리도록 하고 싶었지만 깃헙 액션을 활용해 코멘트를 다는 방법을 찾지 못했습니다. 그래서 차선책으로 분석 결과 링크를 제공하도록 변경했습니다. 

아래와 같이 소나큐브 호스트 링크를 제공하고 분석 결과를 확인할 수 있습니다.
`BidMarket-pr number` 의 분석 결과를 확인하면 됩니다

Bug, Critical 혹은 Major 부분만 확인하면 코드 리뷰를 받기 전 실수나 개선점을 확인할 수 있을것 같긴합니다. 

적용하다가 별로다 싶으면 로컬에 소나 린트를 적용하거나 리뷰를 더 주의해서 살펴보면 충분히 커버할 수 있는 부분이라
해보다가 별로면 버려도 될것 같습니다~~

<img width="946" alt="스크린샷 2022-07-25 오후 9 49 26" src="https://user-images.githubusercontent.com/57293011/180783105-1a02ae77-1f70-404a-9144-90128f419457.png">

<img width="1349" alt="스크린샷 2022-07-25 오후 9 54 35" src="https://user-images.githubusercontent.com/57293011/180783756-ee20968f-6dad-4f39-a20c-2dd6525c5035.png">

<img width="322" alt="image" src="https://user-images.githubusercontent.com/57293011/180784059-f1b62a33-da01-4d17-8375-a20c6aa595e8.png">


<img width="1341" alt="스크린샷 2022-07-25 오후 9 54 00" src="https://user-images.githubusercontent.com/57293011/180783793-700d808c-b206-48ff-8015-eb4cdade7df5.png">
