### PR TITLE
[BM-52] User, Group, Permission 엔티티 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ jacoco {
 }
 
 dependencies {
+    // 테스트를 위해 임시 사용
+    implementation 'com.h2database:h2:2.1.212'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -50,6 +53,16 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+jacocoTestReport {
+    executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+    }
 }
 
 sonarqube {

--- a/src/main/java/com/saiko/bidmarket/user/entity/Group.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/Group.java
@@ -1,0 +1,57 @@
+package com.saiko.bidmarket.user.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Entity
+public class Group {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotBlank
+  @Column(length = 20)
+  private String name;
+
+  @OneToMany(mappedBy = "group")
+  private List<GroupPermission> permissions = new ArrayList<>();
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<GrantedAuthority> getAuthorities() {
+    return permissions.stream()
+                      .map(gp -> new SimpleGrantedAuthority(gp.getPermission().getName()))
+                      .collect(Collectors.toList());
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("id", id)
+        .append("name", name)
+        .append("permissions", permissions)
+        .toString();
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/entity/GroupPermission.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/GroupPermission.java
@@ -1,0 +1,37 @@
+package com.saiko.bidmarket.user.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class GroupPermission {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "group_id")
+  private Group group;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "permission_id")
+  private Permission permission;
+
+  public Long getId() {
+    return id;
+  }
+
+  public Group getGroup() {
+    return group;
+  }
+
+  public Permission getPermission() {
+    return permission;
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/entity/Permission.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/Permission.java
@@ -1,0 +1,40 @@
+package com.saiko.bidmarket.user.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+@Entity
+public class Permission {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotBlank
+  @Column(length = 20)
+  private String name;
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("id", id)
+        .append("name", name)
+        .toString();
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -23,12 +23,8 @@ public class User extends BaseTime {
   private Long id;
 
   @NotBlank
-  @Column(length = 64, unique = true)
-  private String email;
-
-  @NotBlank
   @Column(length = 20)
-  private String nickname;
+  private String username;
 
   @NotBlank
   @Column(length = 512)
@@ -38,23 +34,28 @@ public class User extends BaseTime {
   @Column(length = 20)
   private String provider;
 
+  @NotBlank
+  @Column(length = 80)
+  private String providerId;
+
   @ManyToOne(optional = false)
   @JoinColumn(name = "group_id")
   private Group group;
 
   protected User() {/*no-op*/}
 
-  public User(String email, String nickname, String profileImage, String provider, Group group) {
-    Assert.isTrue(isNotBlank(email), "Email must be provided");
-    Assert.isTrue(isNotBlank(nickname), "Nickname must be provided");
+  public User(String username, String profileImage, String provider, String providerId, Group group) {
+    Assert.isTrue(isNotBlank(username), "Username must be provided");
     Assert.isTrue(isNotBlank(profileImage), "ProfileImage must be provided");
     Assert.isTrue(isNotBlank(provider), "ProfileImage must be provided");
+    Assert.isTrue(isNotBlank(providerId), "ProviderId must be provided");
     Assert.notNull(group, "Group must be provided");
 
-    this.email = email;
-    this.nickname = nickname;
+    this.username = username;
     this.profileImage = profileImage;
     this.provider = provider;
+    this.providerId = providerId;
     this.group = group;
   }
+
 }

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -1,0 +1,61 @@
+package com.saiko.bidmarket.user.entity;
+
+import static org.apache.commons.lang3.StringUtils.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
+
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.entity.BaseTime;
+import com.sun.istack.NotNull;
+
+@Entity
+public class User extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotBlank
+  @Column(length = 64, unique = true)
+  private String email;
+
+  @NotBlank
+  @Column(length = 20)
+  private String nickname;
+
+  @NotBlank
+  @Column(length = 512)
+  private String profileImage;
+
+  @NotBlank
+  @Column(length = 20)
+  private String provider;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "group_id")
+  private Group group;
+
+  protected User() {/*no-op*/}
+
+  public User(String email, String nickname, String profileImage, String provider, Group group) {
+    Assert.isTrue(isNotBlank(email), "Email must be provided");
+    Assert.isTrue(isNotBlank(nickname), "Nickname must be provided");
+    Assert.isTrue(isNotBlank(profileImage), "ProfileImage must be provided");
+    Assert.isTrue(isNotBlank(provider), "ProfileImage must be provided");
+    Assert.notNull(group, "Group must be provided");
+
+    this.email = email;
+    this.nickname = nickname;
+    this.profileImage = profileImage;
+    this.provider = provider;
+    this.group = group;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -14,7 +14,6 @@ import javax.validation.constraints.NotBlank;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.entity.BaseTime;
-import com.sun.istack.NotNull;
 
 @Entity
 public class User extends BaseTime {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,4 +6,5 @@ spring:
           clientId: '{google client-id}'
           clientSecret: '{google client-secret}'
           scope:
+            - email
             - profile

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,9 @@ spring:
 
   sql:
     init:
-      schema-locations: classpath:sql/user/user_schema.sql
+      schema-locations:
+        - classpath:sql/user/user_schema.sql
+        - classpath:sql/product/product_schema.sql
       data-locations: classpath:sql/user/user_data.sql
       encoding: UTF-8
       mode: always
@@ -16,7 +18,7 @@ spring:
     database: mysql
     open-in-view: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
       hibernate.format_sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,5 +30,4 @@ spring:
           clientId: '{google client-id}'
           clientSecret: '{google client-secret}'
           scope:
-            - email
             - profile

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,26 @@
 spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      schema-locations: classpath:sql/user/user_schema.sql
+      data-locations: classpath:sql/user/user_data.sql
+      encoding: UTF-8
+      mode: always
+
+  jpa:
+    database: mysql
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
+      hibernate.format_sql: true
+
   security:
     oauth2.client:
       registration:

--- a/src/main/resources/sql/product/product_schema.sql
+++ b/src/main/resources/sql/product/product_schema.sql
@@ -3,26 +3,26 @@ DROP TABLE IF EXISTS `product` CASCADE;
 
 CREATE TABLE `product`
 (
-    id            bigint       NOT NULL,
-    title         varchar(16)  NOT NULL,
-    description   varchar(500) NOT NULL,
-    minimum_price int          NOT NULL,
-    category      varchar(255) NOT NULL,
-    location      varchar(255) NOT NULL,
-    expire_at     timestamp    NOT NULL,
+    id            bigint       not null auto_increment,
+    title         varchar(16)  not null,
+    description   varchar(500) not null,
+    minimum_price int          not null,
+    category      varchar(100) not null,
+    location      varchar(100),
+    expire_at     datetime     not null,
     created_at    timestamp,
     updated_at    timestamp,
-    PRIMARY KEY (id)
+    primary key (id)
 );
 
 CREATE TABLE `image`
 (
-    id         bigint       NOT NULL,
-    product_id bigint       NOT NULL,
-    url        varchar(512) NOT NULL,
-    `order`    int,
+    id         bigint       not null auto_increment,
+    product_id bigint,
+    url        varchar(512) not null,
+    `order`    int          not null,
     created_at timestamp,
     updated_at timestamp,
-    PRIMARY KEY (id),
+    primary key (id),
     CONSTRAINT fk_product_id_for_image FOREIGN KEY (product_id) REFERENCES `product` (id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );

--- a/src/main/resources/sql/product/product_schema.sql
+++ b/src/main/resources/sql/product/product_schema.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS `image` CASCADE;
+DROP TABLE IF EXISTS `product` CASCADE;
+
+CREATE TABLE `product`
+(
+    id            bigint       NOT NULL,
+    title         varchar(16)  NOT NULL,
+    description   varchar(500) NOT NULL,
+    minimum_price int          NOT NULL,
+    category      varchar(255) NOT NULL,
+    location      varchar(255) NOT NULL,
+    expire_at     timestamp    NOT NULL,
+    created_at    timestamp,
+    updated_at    timestamp,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE `image`
+(
+    id         bigint       NOT NULL,
+    product_id bigint       NOT NULL,
+    url        varchar(512) NOT NULL,
+    `order`    int,
+    created_at timestamp,
+    updated_at timestamp,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_product_id_for_image FOREIGN KEY (product_id) REFERENCES `product` (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,3 +1,6 @@
+DROP TABLE IF EXISTS `image` CASCADE;
+DROP TABLE IF EXISTS `product` CASCADE;
+
 CREATE TABLE `product`
 (
     id            bigint       not null auto_increment,
@@ -7,8 +10,8 @@ CREATE TABLE `product`
     category      varchar(100) not null,
     location      varchar(100),
     expire_at     datetime     not null,
-    created_at    datetime,
-    updated_at    datetime,
+    created_at    timestamp,
+    updated_at    timestamp,
     primary key (id)
 );
 
@@ -18,8 +21,8 @@ CREATE TABLE `image`
     product_id bigint,
     url        varchar(512) not null,
     `order`    int          not null,
-    created_at datetime,
-    updated_at datetime,
+    created_at timestamp,
+    updated_at timestamp,
     primary key (id),
     CONSTRAINT fk_product_id_for_image FOREIGN KEY (product_id) REFERENCES `product` (id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );

--- a/src/main/resources/sql/user/user_data.sql
+++ b/src/main/resources/sql/user/user_data.sql
@@ -1,0 +1,17 @@
+INSERT INTO `permission`(id, name)
+VALUES (1, 'ROLE_USER'),
+       (2, 'ROLE_ADMIN')
+;
+
+INSERT INTO `group`(id, name)
+VALUES (1, 'USER_GROUP'),
+       (2, 'ADMIN_GROUP')
+;
+
+-- USER_GROUP (ROLE_USER)
+-- ADMIN_GROUP (ROLE_USER, ROLE_ADMIN)
+INSERT INTO `group_permission`(id, group_id, permission_id)
+VALUES (1, 1, 1),
+       (2, 2, 1),
+       (3, 2, 2)
+;

--- a/src/main/resources/sql/user/user_schema.sql
+++ b/src/main/resources/sql/user/user_schema.sql
@@ -1,0 +1,44 @@
+DROP TABLE IF EXISTS `group_permission` CASCADE;
+DROP TABLE IF EXISTS `user` CASCADE;
+DROP TABLE IF EXISTS `group` CASCADE;
+DROP TABLE IF EXISTS `permission` CASCADE;
+
+CREATE TABLE `permission`
+(
+    id   bigint      NOT NULL,
+    name varchar(20) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE `group`
+(
+    id   bigint      NOT NULL,
+    name varchar(20) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE `group_permission`
+(
+    id            bigint NOT NULL,
+    group_id      bigint NOT NULL,
+    permission_id bigint NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT unq_group_id_permission_id UNIQUE (group_id, permission_id),
+    CONSTRAINT fk_group_id_for_group_permission FOREIGN KEY (group_id) REFERENCES `group` (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_permission_id_for_group_permission FOREIGN KEY (permission_id) REFERENCES permission (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+CREATE TABLE `user`
+(
+    id            bigint      NOT NULL AUTO_INCREMENT,
+    email         varchar(64) NOT NULL,
+    nickname      varchar(20) NOT NULL,
+    provider      varchar(20) NOT NULL,
+    profile_image varchar(512) DEFAULT NULL,
+    group_id      bigint      NOT NULL,
+    created_at    timestamp,
+    updated_at    timestamp,
+    PRIMARY KEY (id),
+    CONSTRAINT unq_email UNIQUE (email),
+    CONSTRAINT fk_group_id_for_user FOREIGN KEY (group_id) REFERENCES `group` (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);

--- a/src/main/resources/sql/user/user_schema.sql
+++ b/src/main/resources/sql/user/user_schema.sql
@@ -31,14 +31,15 @@ CREATE TABLE `group_permission`
 CREATE TABLE `user`
 (
     id            bigint      NOT NULL AUTO_INCREMENT,
-    email         varchar(64) NOT NULL,
-    nickname      varchar(20) NOT NULL,
+    username      varchar(20) NOT NULL,
     provider      varchar(20) NOT NULL,
+    provider_id   varchar(80) NOT NULL,
     profile_image varchar(512) DEFAULT NULL,
     group_id      bigint      NOT NULL,
     created_at    timestamp,
     updated_at    timestamp,
     PRIMARY KEY (id),
-    CONSTRAINT unq_email UNIQUE (email),
+    CONSTRAINT unq_username UNIQUE (username),
+    CONSTRAINT unq_provider_and_id UNIQUE (provider, provider_id),
     CONSTRAINT fk_group_id_for_user FOREIGN KEY (group_id) REFERENCES `group` (id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );


### PR DESCRIPTION
## 주요사항

- #9 와 DB 관련 설정부분들이 일부 겹치는데 이러한 부분은 제외하고 봐주시면 될것 같습니다.

### oauth scope에 이메일을 추가하였습니다.
- 닉네임을 principal로 쓸경우 닉네임을 변경할 때 마타 토큰을 재발급 해야합니다.
- 이메일을 oauth 로 받아서 principal로 쓸 수 있도록 엔티티를 구성하였습니다.

### ROLE_USER, ROLE_ADMIN 과 같은 권한 정보를 DB에 저장하여 관리합니다.

- 권한 정보가 코드상에 노출되지 않는다는 장점때문에 차용하였습니다.
- 토큰에 권한 정보가 포함되어있기 때문에 토큰 발급시 외에는 추가적인 쿼리가 발생하지 않을것입니다. 

### 리소스 폴더의 sql 파일들을 도메인별로 폴더를 정리하여 두고자합니다.
- <img width="410" alt="image" src="https://user-images.githubusercontent.com/28651727/180967991-b784a4b4-7106-44e3-a012-10bcf021a100.png">
- #9 pr이 머지되면 수정하여 반영하겠습니다.
