### PR TITLE
[BM-52] UserService 회원가입 구현 및 테스트

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/exception/NotFoundException.java
+++ b/src/main/java/com/saiko/bidmarket/common/exception/NotFoundException.java
@@ -1,0 +1,13 @@
+package com.saiko.bidmarket.common.exception;
+
+public class NotFoundException extends RuntimeException {
+
+  public NotFoundException() {
+    super();
+  }
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/repository/GroupRepository.java
+++ b/src/main/java/com/saiko/bidmarket/user/repository/GroupRepository.java
@@ -1,0 +1,11 @@
+package com.saiko.bidmarket.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.saiko.bidmarket.user.entity.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+  Optional<Group> findByName(String name);
+}

--- a/src/main/java/com/saiko/bidmarket/user/repository/UserRepository.java
+++ b/src/main/java/com/saiko/bidmarket/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.saiko.bidmarket.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.saiko.bidmarket.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  @Query("select u from User u join fetch u.group g left join fetch g.permissions gp join fetch gp.permission where u.username = :username")
+  Optional<User> findByUsername(String username);
+
+  @Query("select u from User u join fetch u.group g left join fetch g.permissions gp join fetch gp.permission where u.provider = :provider and u.providerId = :providerId")
+  Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultGroupService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultGroupService.java
@@ -1,0 +1,33 @@
+package com.saiko.bidmarket.user.service;
+
+import static org.apache.commons.lang3.StringUtils.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.repository.GroupRepository;
+
+@Service
+@Transactional
+public class DefaultGroupService implements GroupService {
+
+  private final GroupRepository groupRepository;
+
+  public DefaultGroupService(GroupRepository groupRepository) {
+    this.groupRepository = groupRepository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Group findByName(String name) {
+    Assert.isTrue(isNotBlank(name), "Name must be provided");
+
+    return groupRepository.findByName(name)
+                          .orElseThrow(() -> new NotFoundException("Group does not exist"));
+
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -1,0 +1,73 @@
+package com.saiko.bidmarket.user.service;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
+
+@Service
+@Transactional
+public class DefaultUserService implements UserService {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final UserRepository userRepository;
+  private final GroupService groupService;
+
+  public DefaultUserService(UserRepository userRepository, GroupService groupService) {
+    this.userRepository = userRepository;
+    this.groupService = groupService;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public User findByProviderAndProviderId(String provider, String providerId) {
+    Assert.hasText(provider, "Provider must be provided");
+    Assert.hasText(providerId, "ProviderId must be provided");
+
+    return userRepository.findByProviderAndProviderId(provider, providerId)
+                         .orElseThrow(() -> new NotFoundException("User does not exist"));
+  }
+
+  @Override
+  @Transactional
+  public User join(OAuth2User oAuth2User, String authorizedClientRegistrationId) {
+    Assert.notNull(oAuth2User, "OAuth2User must be provided");
+    Assert.hasText(authorizedClientRegistrationId,
+                   "AuthorizedClientRegistrationId must be provided");
+
+    String providerId = oAuth2User.getName();
+    try {
+      User user = findByProviderAndProviderId(authorizedClientRegistrationId, providerId);
+      log.warn("Already exists: {} for (provider: {}, providerId: {})", user,
+               authorizedClientRegistrationId, providerId);
+      return user;
+    } catch (NotFoundException e) {
+      Map<String, Object> attributes = oAuth2User.getAttributes();
+      @SuppressWarnings("unchecked")
+      Map<String, Object> properties = (Map<String, Object>)attributes.get("properties");
+
+      if (properties == null) {
+        throw new IllegalArgumentException("OAuth2User properties is empty");
+      }
+
+      String username = (String)properties.get("name");
+      String profileImage = (String)properties.get("picture");
+      Group group = groupService.findByName("USER_GROUP");
+
+      User user = new User(username, profileImage, authorizedClientRegistrationId, providerId,
+                           group);
+      return userRepository.save(user);
+    }
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/GroupService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/GroupService.java
@@ -1,7 +1,5 @@
 package com.saiko.bidmarket.user.service;
 
-import java.util.Optional;
-
 import com.saiko.bidmarket.user.entity.Group;
 
 public interface GroupService {

--- a/src/main/java/com/saiko/bidmarket/user/service/GroupService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/GroupService.java
@@ -1,0 +1,11 @@
+package com.saiko.bidmarket.user.service;
+
+import java.util.Optional;
+
+import com.saiko.bidmarket.user.entity.Group;
+
+public interface GroupService {
+
+  Group findByName(String name);
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/UserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/UserService.java
@@ -1,0 +1,11 @@
+package com.saiko.bidmarket.user.service;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.saiko.bidmarket.user.entity.User;
+
+public interface UserService {
+  User findByProviderAndProviderId(String provider, String providerId);
+
+  User join(OAuth2User oAuth2User, String authorizedClientRegistrationId);
+}

--- a/src/test/java/com/saiko/bidmarket/user/service/DefaultGroupServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/service/DefaultGroupServiceTest.java
@@ -1,0 +1,93 @@
+package com.saiko.bidmarket.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.repository.GroupRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultGroupServiceTest {
+
+  @Mock
+  GroupRepository groupRepository;
+
+  @InjectMocks
+  DefaultGroupService defaultGroupService;
+
+  @Nested
+  @DisplayName("findByName 메서드는")
+  class DescribeFindByName {
+
+    @Nested
+    @DisplayName("name 값이 비어있으면")
+    class ContextWithBlankName {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t"})
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다.")
+      void ItThrowsIllegalArgumentException(String src) {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> defaultGroupService.findByName(src));
+      }
+    }
+
+    @Nested
+    @DisplayName("해당하는 group 이 존재 하면")
+    class ContextWithExist {
+
+      @Test
+      @DisplayName("해당 group 객체를 반환한다")
+      void ItResponseGroup() {
+        //given
+        String target = "USER_GROUP";
+
+        Group group = new Group();
+        ReflectionTestUtils.setField(group, "name", target);
+        given(groupRepository.findByName(anyString())).willReturn(Optional.of(group));
+
+        //when
+        Group findGroup = defaultGroupService.findByName(target);
+
+        //then
+        assertEquals(target, findGroup.getName());
+      }
+    }
+
+    @Nested
+    @DisplayName("해당하는 group 이 존재하지 않으면")
+    class ContextWithNotExist {
+
+      @Test
+      @DisplayName("NotfoundException 에러를 발생시킨다")
+      void ItNotFoundException() {
+        //given
+        given(groupRepository.findByName(anyString())).willReturn(Optional.empty());
+
+        //when, then
+        assertThrows(NotFoundException.class, () -> defaultGroupService.findByName("USER_GROUP"));
+
+      }
+    }
+
+  }
+
+}

--- a/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
@@ -1,0 +1,181 @@
+package com.saiko.bidmarket.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+class DefaultUserServiceTest {
+
+  @Mock
+  UserRepository userRepository;
+
+  @Mock
+  GroupService groupService;
+
+  @InjectMocks
+  DefaultUserService defaultUserService;
+
+  @Order(1)
+  @Nested
+  @DisplayName("findByProviderAndProviderId 는")
+  class DescribeFindByProviderAndProviderId {
+
+    @Nested
+    @DisplayName("provider 가 빈 값이면")
+    class ContextWithProviderIsBlank {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t"})
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다.")
+      void ItThrowsIllegalArgumentException(String src) {
+        assertThrows(IllegalArgumentException.class,
+                     () -> defaultUserService.findByProviderAndProviderId(src, "123"));
+      }
+    }
+
+    @Nested
+    @DisplayName("providerId 가 빈 값이면")
+    class ContextWithProviderIdIsBlank {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\n", "\t"})
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다.")
+      void ItThrowsIllegalArgumentException(String src) {
+        assertThrows(IllegalArgumentException.class,
+                     () -> defaultUserService.findByProviderAndProviderId("123", src));
+
+      }
+    }
+  }
+
+  @Order(2)
+  @Nested
+  @DisplayName("join 메서드는")
+  class DescribeJoin {
+
+    @Nested
+    @DisplayName("oAuth2User 값이 null 이면")
+    class ContextWithOAuth2UserNull {
+
+      @Test
+      @DisplayName("IllegalArgumentException")
+      void ItIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> defaultUserService.join(null, "123"));
+      }
+    }
+
+    @Nested
+    @DisplayName("authorizedClientRegistrationId 값이 빈값 이면")
+    class ContextWithBlankAuthorizedClientRegistrationId {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"\t", "\n"})
+      @DisplayName("IllegalArgumentException 에러를 발생 시킨다")
+      void ItThrowsIllegalArgumentException(String src) {
+        OAuth2User oAuth2User = new DefaultOAuth2User(Collections.emptyList(),
+                                                      Map.of("1", "1"),
+                                                      "1");
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> defaultUserService.join(oAuth2User, src));
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 하는 유저가 존재하면")
+    class ContextWithUserAlreadyExist {
+
+      @Test
+      @DisplayName("해당 유저를 반환한다")
+      void ItReturnUser() {
+        //given
+        String provider = "google";
+        String providerId = "testProviderId";
+        User user = new User("username", "test", provider, providerId, new Group());
+        OAuth2User oAuth2User = new DefaultOAuth2User(Collections.emptyList(),
+                                                      Map.of("name", providerId), "name");
+        given(userRepository.findByProviderAndProviderId(anyString(), anyString())).willReturn(
+            Optional.of(user));
+        //when
+        User joinedUser = defaultUserService.join(oAuth2User, provider);
+
+        //then
+        String joinedUserProvider = (String)ReflectionTestUtils.getField(joinedUser, "provider");
+        String joinedUserProviderId = (String)ReflectionTestUtils.getField(joinedUser,
+                                                                           "providerId");
+        assertAll(
+            () -> assertEquals(provider, joinedUserProvider),
+            () -> assertEquals(providerId, joinedUserProviderId)
+        );
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 하는 유저가 존재하지 않으면")
+    class ContextWithNotExist {
+
+      @Test
+      @DisplayName("유저를 생성하고 반환한다.")
+      void It() {
+        //given
+        Group userGroup = new Group();
+        ReflectionTestUtils.setField(userGroup, "name", "USER_GROUP");
+        given(groupService.findByName(anyString())).willReturn(userGroup);
+        given(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+            .willReturn(Optional.empty());
+
+        given(groupService.findByName(anyString())).willReturn(new Group());
+        Map<String, Object> properties = Map.of("name", "test", "picture", "testUrl");
+        Map<String, Object> attributes = Map.of("name", "test", "properties", properties);
+        OAuth2User oAuth2User = new DefaultOAuth2User(Collections.emptyList(), attributes, "name");
+
+        //when
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+        User user = defaultUserService.join(oAuth2User, "google");
+
+        //then
+        String savedUserUsername = (String)ReflectionTestUtils.getField(user, User.class,
+                                                                        "username");
+        String savedUserProfileImg = (String)ReflectionTestUtils.getField(user, User.class,
+                                                                          "profileImage");
+
+        assertAll(
+            () -> assertEquals(savedUserUsername, "test"),
+            () -> assertEquals(savedUserProfileImg, "testUrl")
+        );
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
## 주요 사항

provider 와 providerId를 통해 유저가 존재하는지 확인하고 존재하지 않으면 유저를 생성하고 저장하는 로직을 구현하였습니다.

유저가 존재하지 않는경우를 위해 NotFoundException 예외를 추가하였습니다.

