### PR TITLE
[BM-124] Rest Docs Asciidoc 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.7.2'
     id 'io.spring.dependency-management' version '1.0.12.RELEASE'
-    id 'org.asciidoctor.convert' version '1.5.8'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'java'
     id 'jacoco'
     id 'org.sonarqube' version '3.0'
@@ -10,6 +10,10 @@ plugins {
 group = 'com.saiko'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
+
+configurations {
+    asciidoctorExtensions
+}
 
 repositories {
     mavenCentral()
@@ -37,8 +41,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.testcontainers:jdbc:1.17.3'
     runtimeOnly 'mysql:mysql-connector-java'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.testcontainers:junit-jupiter:1.17.2'
     testImplementation 'org.testcontainers:mysql:1.17.2'
@@ -51,6 +57,7 @@ tasks.named('test') {
 }
 
 tasks.named('asciidoctor') {
+    configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
     dependsOn test
 }
@@ -78,4 +85,22 @@ dependencyManagement {
     imports {
         mavenBom "org.testcontainers:testcontainers-bom:${testcontainersVersion}"
     }
+}
+
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'src/main/resources/static/docs'
+    }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.testcontainers:junit-jupiter:1.17.2'
     testImplementation 'org.testcontainers:mysql:1.17.2'

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -1,0 +1,15 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+= Bid Market
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+== Product
+=== Create Product
+==== Request
+include::{snippets}/Create product/http-request.adoc[]
+include::{snippets}/Create product/request-fields.adoc[]
+==== Response
+include::{snippets}/Create product/http-response.adoc[]


### PR DESCRIPTION
* Rest Docs 적용을 위하여 Asciidoc 설정을 추가하였습니다.

* 적용 방법
1. Controller 테스트 작성
2. Controller 테스트 돌리기
3. `/build/generated-snippets/XX` 경로로 들어가면 Controller 테스트에 해당하는 adoc 파일이 생성된 것을 확인할 수 있음
4. `/src/docs/asciidoc/api.adoc` 파일 내에 API에 해당하는 명세 작성 (adoc 파일 추가)