### PR TITLE
[BM-128] :bug: 상품 상세조회 응답 객체 카테고리 필드 수정

### DIFF
--- a/src/main/java/com/saiko/bidmarket/product/Category.java
+++ b/src/main/java/com/saiko/bidmarket/product/Category.java
@@ -20,21 +20,21 @@ public enum Category {
   PLANT("식물"),
   ETC("기타 중고 물품");
 
-  private final String name;
+  private final String displayName;
 
-  Category(String name) {
-    this.name = name;
+  Category(String displayName) {
+    this.displayName = displayName;
   }
 
   @JsonValue
-  public String getName() {
-    return name;
+  public String getDisplayName() {
+    return displayName;
   }
 
   @JsonCreator
   public static Category from(String name) {
     for (Category category : Category.values()) {
-      if (category.getName().equals(name)) {
+      if (category.getDisplayName().equals(name)) {
         return category;
       }
     }

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
@@ -58,7 +58,7 @@ public class ProductDetailResponse {
     this.title = product.getTitle();
     this.description = product.getDescription();
     this.minimumPrice = product.getMinimumPrice();
-    this.categoryName = product.getCategory().name();
+    this.categoryName = product.getCategory().getName();
     this.location = product.getLocation();
     this.expireAt = product.getExpireAt();
     this.createdAt = product.getCreatedAt();

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
@@ -58,7 +58,7 @@ public class ProductDetailResponse {
     this.title = product.getTitle();
     this.description = product.getDescription();
     this.minimumPrice = product.getMinimumPrice();
-    this.categoryName = product.getCategory().getName();
+    this.categoryName = product.getCategory().getDisplayName();
     this.location = product.getLocation();
     this.expireAt = product.getExpireAt();
     this.createdAt = product.getCreatedAt();

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -105,7 +105,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getName());
+        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});
@@ -162,7 +162,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", title);
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getName());
+        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});
@@ -194,7 +194,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", description);
-        requestMap.put("category", DIGITAL_DEVICE.getName());
+        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("imageUrl1", new String[]{"imageUrl1, imageUrl2"});
@@ -225,7 +225,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getName());
+        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", Arrays.asList("imageUrl1",
@@ -261,7 +261,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getName());
+        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
         requestMap.put("minimumPrice", 100);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("imageUrl1", new String[]{"imageUrl1, imageUrl2"});


### PR DESCRIPTION
### 상품 상세조회 응답 객체 수정

![image](https://user-images.githubusercontent.com/61923768/181667239-41b0fda8-e1e6-42ef-8ef4-e81c409493f5.png)
- Enum Type은 기본적으로 Oridinal(순서)와 Name(이름 - 빨간색)을 가지고 있습니다.
- 여기에 필요에 따라 추가적인 필드 값들을 구현할 수 있는 데, 저희가 사용하는 Category에 name이라는 필드(노란색)를 추가하였습니다.
- 기본적으로 가지고 있는 Name에 대한 조회 함수는 `name()`이고 추가한 name 필드 조회 함수는 `getName()`입니다.

### 수정사항
- 응답객체에서는 `getName()`을 통해 새로 정의된 name을 가져 와야 하는데 `name()`함수로 기본 name을 가져오고 있어서 수정하였습니다.

### 논의사항
name이라는 필드명 자체가 헷갈릴 여지가 있어서 필드명을 변경하는 것도 고려해보면 좋을 것 같습니다!
