### PR TITLE
[BM-92] JWT 관련 수정

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
@@ -102,10 +102,10 @@ public class Jwt {
       this.exp = decodedJWT.getExpiresAt();
     }
 
-    public static Claims from(String username, String[] roles) {
+    public static Claims from(String userId, String[] roles) {
 
       Claims claims = new Claims();
-      claims.userId = username;
+      claims.userId = userId;
       claims.roles = roles;
       return claims;
     }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
@@ -44,7 +44,7 @@ public class Jwt {
     if (expirySecond > 0) {
       builder.withExpiresAt(new Date(now.getTime() + expirySecond * 1000L));
     }
-    builder.withClaim("username", claims.username);
+    builder.withClaim("userId", claims.userId);
     builder.withArrayClaim("roles", claims.roles);
     return builder.sign(algorithm);
   }
@@ -81,7 +81,7 @@ public class Jwt {
 
   public static class Claims {
 
-    String username;
+    String userId;
     String[] roles;
     Date iat;
     Date exp;
@@ -91,10 +91,10 @@ public class Jwt {
 
     Claims(DecodedJWT decodedJWT) {
 
-      Claim username = decodedJWT.getClaim("username");
-      if (!username.isNull())
-        this.username = username.asString();
-      Claim roles = decodedJWT.getClaim("role");
+      Claim userId = decodedJWT.getClaim("userId");
+      if (!userId.isNull())
+        this.userId = userId.asString();
+      Claim roles = decodedJWT.getClaim("roles");
       if (!roles.isNull()) {
         this.roles = roles.asArray(String.class);
       }
@@ -105,7 +105,7 @@ public class Jwt {
     public static Claims from(String username, String[] roles) {
 
       Claims claims = new Claims();
-      claims.username = username;
+      claims.userId = username;
       claims.roles = roles;
       return claims;
     }
@@ -113,7 +113,7 @@ public class Jwt {
     public Map<String, Object> asMap() {
 
       Map<String, Object> map = new HashMap<>();
-      map.put("username", username);
+      map.put("userId", userId);
       map.put("roles", roles);
       map.put("iat", iat());
       return map;
@@ -143,7 +143,7 @@ public class Jwt {
     public String toString() {
 
       return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-          .append("username", username)
+          .append("userId", userId)
           .append("roles", Arrays.toString(roles))
           .append("iat", iat)
           .append("exp", exp)

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
@@ -8,14 +8,14 @@ public class JwtAuthentication {
 
   public final String token;
 
-  public final String username;
+  public final String userid;
 
-  public JwtAuthentication(String token, String username) {
+  public JwtAuthentication(String token, String userid) {
     Assert.hasText(token, "token must be provided");
-    Assert.hasText(username, "username must be provided");
+    Assert.hasText(userid, "username must be provided");
 
     this.token = token;
-    this.username = username;
+    this.userid = userid;
   }
 
   @Override
@@ -23,7 +23,7 @@ public class JwtAuthentication {
 
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
         .append("token", token)
-        .append("username", username)
+        .append("userId", userid)
         .build();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
@@ -8,14 +8,14 @@ public class JwtAuthentication {
 
   private final String token;
 
-  private final String userid;
+  private final String userId;
 
-  public JwtAuthentication(String token, String userid) {
+  public JwtAuthentication(String token, String userId) {
     Assert.hasText(token, "token must be provided");
-    Assert.hasText(userid, "username must be provided");
+    Assert.hasText(userId, "userId must be provided");
 
     this.token = token;
-    this.userid = userid;
+    this.userId = userId;
   }
 
   @Override
@@ -23,11 +23,11 @@ public class JwtAuthentication {
 
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
         .append("token", token)
-        .append("userId", userid)
+        .append("userId", userId)
         .build();
   }
 
-  public String getUserid() {
-    return userid;
+  public String getUserId() {
+    return userId;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
@@ -6,9 +6,9 @@ import org.springframework.util.Assert;
 
 public class JwtAuthentication {
 
-  public final String token;
+  private final String token;
 
-  public final String userid;
+  private final String userid;
 
   public JwtAuthentication(String token, String userid) {
     Assert.hasText(token, "token must be provided");
@@ -25,5 +25,9 @@ public class JwtAuthentication {
         .append("token", token)
         .append("userId", userid)
         .build();
+  }
+
+  public String getUserid() {
+    return userid;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -57,7 +57,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
           String userId = claims.userId;
           List<GrantedAuthority> authorities = getAuthorities(claims);
 
-          if (isNotEmpty(userId) && authorities.size() > 0) {
+          if (isNotBlank(userId) && authorities.size() > 0) {
             JwtAuthenticationToken authentication =
                 new JwtAuthenticationToken(new JwtAuthentication(token, userId), null,
                                            authorities);

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.*;
 import static org.apache.logging.log4j.util.Strings.*;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -51,15 +51,15 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
       String token = getToken(request);
       if (token != null) {
         try {
-          Jwt.Claims claims = verify(token);
+          Jwt.Claims claims = verify(token.substring(7));
           log.debug("Jwt parse result: {}", claims);
 
-          String username = claims.username;
+          String userId = claims.userId;
           List<GrantedAuthority> authorities = getAuthorities(claims);
 
-          if (isNotEmpty(username) && authorities.size() > 0) {
+          if (isNotEmpty(userId) && authorities.size() > 0) {
             JwtAuthenticationToken authentication =
-                new JwtAuthenticationToken(new JwtAuthentication(token, username), null,
+                new JwtAuthenticationToken(new JwtAuthentication(token, userId), null,
                                            authorities);
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -81,7 +81,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     String token = request.getHeader(headerKey);
 
-    if (isNotEmpty(token)) {
+    if (isNotBlank(token)) {
       log.debug("Jwt authorization api detected: {}", token);
       return URLDecoder.decode(token, StandardCharsets.UTF_8);
     }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import static org.apache.logging.log4j.util.Strings.*;
 
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -82,11 +83,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     if (isNotEmpty(token)) {
       log.debug("Jwt authorization api detected: {}", token);
-      try {
-        return URLDecoder.decode(token, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        log.error(e.getMessage(), e);
-      }
+      return URLDecoder.decode(token, StandardCharsets.UTF_8);
     }
 
     return null;

--- a/src/main/java/com/saiko/bidmarket/common/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/saiko/bidmarket/common/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -62,12 +62,11 @@ public class OAuth2AuthenticationSuccessHandler extends
 
   private String generateLoginSuccessJson(User user) {
     String token = generateToken(user);
-    log.debug("Jwt({}) created for oauth2 login user {}", token, user.getUsername());
-    return "{\"token\":\"" + token + "\", \"username\":\"" + user.getUsername() + "\", \"group\":\""
-        + user.getGroup().getName() + "\"}";
+    log.debug("Jwt({}) created for oauth2 login user {}", token, user.getStringId());
+    return "{\"token\":\"" + token + "\"}";
   }
 
   private String generateToken(User user) {
-    return jwt.sign(Jwt.Claims.from(user.getUsername(), new String[]{"ROLE_USER"}));
+    return jwt.sign(Jwt.Claims.from(user.getStringId(), new String[]{"ROLE_USER"}));
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -60,6 +60,10 @@ public class User extends BaseTime {
     this.group = group;
   }
 
+  public String getStringId() {
+    return id.toString();
+  }
+
   public String getUsername() {
     return username;
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
             - profile
 
 jwt:
-  header: token
+  header: Authorization
   issuer: saiko
-  client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
-  expiry-seconds: 60
+  client-secret: '{client-secret'
+  expiry-seconds: 100000


### PR DESCRIPTION
기존 JWT 검증 관련 로직에 문제가 있어서 수정했습니다.

username -> userId

유저 관련 노출 정보 삭제

테스트 화면입니다.

컨트롤러에서 유저 ID를 받으려면 메서드 인자로

`@AuthenticationPrincipal JwtAuthentication authentication`

을 받고 `authentication.getUserId()` 로 접근할 수 있습니다. 

이 UserId는 String 타입입니다.

예시 
```  
public ProductCreateResponse create(
      @AuthenticationPrincipal JwtAuthentication athentication
      @RequestBody @Valid ProductCreateRequest productCreateRequest) {
    long productId = productService.create(
              productCreateRequest,
              athentication.userId
              )
      
    return ProductCreateResponse.from(productId);
  }
```

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/57293011/181765517-8cb913c0-4d4c-422f-939a-a2cd8ef26c8c.png">
