### PR TITLE
[BM-136] 상품 등록 API 코드 수정 (토큰 인증, 유저 정보를 받도록), Token에 UserId를 Long타입으로 받도록 변경

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/Jwt.java
@@ -81,7 +81,7 @@ public class Jwt {
 
   public static class Claims {
 
-    String userId;
+    Long userId;
     String[] roles;
     Date iat;
     Date exp;
@@ -93,7 +93,7 @@ public class Jwt {
 
       Claim userId = decodedJWT.getClaim("userId");
       if (!userId.isNull())
-        this.userId = userId.asString();
+        this.userId = userId.asLong();
       Claim roles = decodedJWT.getClaim("roles");
       if (!roles.isNull()) {
         this.roles = roles.asArray(String.class);
@@ -102,7 +102,7 @@ public class Jwt {
       this.exp = decodedJWT.getExpiresAt();
     }
 
-    public static Claims from(String userId, String[] roles) {
+    public static Claims from(Long userId, String[] roles) {
 
       Claims claims = new Claims();
       claims.userId = userId;

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthentication.java
@@ -8,11 +8,11 @@ public class JwtAuthentication {
 
   private final String token;
 
-  private final String userId;
+  private final Long userId;
 
-  public JwtAuthentication(String token, String userId) {
+  public JwtAuthentication(String token, Long userId) {
     Assert.hasText(token, "token must be provided");
-    Assert.hasText(userId, "userId must be provided");
+    Assert.isTrue(userId > 0, "userId must be provided");
 
     this.token = token;
     this.userId = userId;
@@ -27,7 +27,7 @@ public class JwtAuthentication {
         .build();
   }
 
-  public String getUserId() {
+  public Long getUserId() {
     return userId;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/saiko/bidmarket/common/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.saiko.bidmarket.common.jwt;
 
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
+import static jdk.dynalink.linker.support.Guards.*;
 import static org.apache.logging.log4j.util.Strings.*;
 
 import java.io.IOException;
@@ -54,10 +55,10 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
           Jwt.Claims claims = verify(token.substring(7));
           log.debug("Jwt parse result: {}", claims);
 
-          String userId = claims.userId;
+          Long userId = claims.userId;
           List<GrantedAuthority> authorities = getAuthorities(claims);
 
-          if (isNotBlank(userId) && authorities.size() > 0) {
+          if (userId > 0 && authorities.size() > 0) {
             JwtAuthenticationToken authentication =
                 new JwtAuthenticationToken(new JwtAuthentication(token, userId), null,
                                            authorities);

--- a/src/main/java/com/saiko/bidmarket/common/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/saiko/bidmarket/common/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -39,7 +39,6 @@ public class OAuth2AuthenticationSuccessHandler extends
       HttpServletResponse response,
       Authentication authentication)
       throws
-      ServletException,
       IOException {
 
     if (authentication instanceof OAuth2AuthenticationToken) {
@@ -62,11 +61,11 @@ public class OAuth2AuthenticationSuccessHandler extends
 
   private String generateLoginSuccessJson(User user) {
     String token = generateToken(user);
-    log.debug("Jwt({}) created for oauth2 login user {}", token, user.getStringId());
+    log.debug("Jwt({}) created for oauth2 login user {}", token, user.getId());
     return "{\"token\":\"" + token + "\"}";
   }
 
   private String generateToken(User user) {
-    return jwt.sign(Jwt.Claims.from(user.getStringId(), new String[]{"ROLE_USER"}));
+    return jwt.sign(Jwt.Claims.from(user.getId(), new String[]{"ROLE_USER"}));
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
@@ -3,6 +3,7 @@ package com.saiko.bidmarket.product.controller;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,11 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.service.ProductService;
-import com.saiko.bidmarket.user.entity.Group;
-import com.saiko.bidmarket.user.entity.User;
 
 @RestController
 @RequestMapping("api/v1/products")
@@ -30,10 +30,9 @@ public class ProductApiController {
   @ResponseStatus(HttpStatus.CREATED)
   // TODO: 로그인한 유저 정보 필요
   public ProductCreateResponse create(
+      @AuthenticationPrincipal JwtAuthentication authentication,
       @RequestBody @Valid ProductCreateRequest productCreateRequest) {
-    long productId = productService.create(productCreateRequest,
-                                           new User("test", "image", "google", "1234",
-                                                    new Group()));
+    long productId = productService.create(productCreateRequest, authentication.getUserId());
     return ProductCreateResponse.from(productId);
   }
 

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
@@ -28,10 +28,10 @@ public class ProductApiController {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
-  // TODO: 로그인한 유저 정보 필요
   public ProductCreateResponse create(
       @AuthenticationPrincipal JwtAuthentication authentication,
-      @RequestBody @Valid ProductCreateRequest productCreateRequest) {
+      @RequestBody @Valid ProductCreateRequest productCreateRequest
+  ) {
     long productId = productService.create(productCreateRequest, authentication.getUserId());
     return ProductCreateResponse.from(productId);
   }

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -4,18 +4,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
-import com.saiko.bidmarket.product.repository.ProductRepository;
-import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.service.UserService;
 
 @Service
 public class DefaultProductService implements ProductService {
+
   private final ProductRepository productRepository;
+  private final UserService userService;
 
   public DefaultProductService(
-      ProductRepository productRepository) {
+      ProductRepository productRepository, UserService userService) {
     this.productRepository = productRepository;
+    this.userService = userService;
   }
 
   @Override
@@ -26,19 +30,20 @@ public class DefaultProductService implements ProductService {
   }
 
   @Override
-  public long create(ProductCreateRequest productCreateRequest, User writer) {
+  public long create(ProductCreateRequest productCreateRequest, Long userId) {
     Assert.notNull(productCreateRequest, "ProductCreateRequest must be provided");
-    Assert.notNull(writer, "Writer must be provided");
+    Assert.notNull(userId, "userId must be provided ");
 
-    Product product = Product.builder()
-                             .title(productCreateRequest.getTitle())
-                             .description(productCreateRequest.getDescription())
-                             .location(productCreateRequest.getLocation())
-                             .category(productCreateRequest.getCategory())
-                             .minimumPrice(productCreateRequest.getMinimumPrice())
-                             .images(productCreateRequest.getImages())
-                             .writer(writer)
-                             .build();
+    final User writer = userService.findById(userId);
+    final Product product = Product.builder()
+                                   .title(productCreateRequest.getTitle())
+                                   .description(productCreateRequest.getDescription())
+                                   .location(productCreateRequest.getLocation())
+                                   .category(productCreateRequest.getCategory())
+                                   .minimumPrice(productCreateRequest.getMinimumPrice())
+                                   .images(productCreateRequest.getImages())
+                                   .writer(writer)
+                                   .build();
     return productRepository.save(product).getId();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -1,12 +1,11 @@
 package com.saiko.bidmarket.product.service;
 
-import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
-import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductService {
 
   Product findById(long id);
 
-  long create(ProductCreateRequest productCreateRequest, User writer);
+  long create(ProductCreateRequest productCreateRequest, Long userId);
 }

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -46,7 +46,8 @@ public class User extends BaseTime {
 
   protected User() {/*no-op*/}
 
-  public User(String username, String profileImage, String provider, String providerId, Group group) {
+  public User(String username, String profileImage, String provider, String providerId,
+              Group group) {
     Assert.isTrue(isNotBlank(username), "Username must be provided");
     Assert.isTrue(isNotBlank(profileImage), "ProfileImage must be provided");
     Assert.isTrue(isNotBlank(provider), "ProfileImage must be provided");
@@ -60,8 +61,8 @@ public class User extends BaseTime {
     this.group = group;
   }
 
-  public String getStringId() {
-    return id.toString();
+  public Long getId() {
+    return id;
   }
 
   public String getUsername() {

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -23,14 +23,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.springframework.beans.factory.annotation.Autowired;;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -40,8 +39,8 @@ import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.service.ProductService;
-import com.saiko.bidmarket.user.entity.User;
 import com.saiko.bidmarket.util.ControllerSetUp;
+import com.saiko.bidmarket.util.WithMockCustomLoginUser;
 
 @WebMvcTest(controllers = ProductApiController.class)
 class ProductApiControllerTest extends ControllerSetUp {
@@ -81,7 +80,7 @@ class ProductApiControllerTest extends ControllerSetUp {
 
   @Nested
   @DisplayName("create 메서드는")
-  @WithMockUser(roles = "USER")
+  @WithMockCustomLoginUser
   class DescribeCreate {
 
     @Nested
@@ -101,7 +100,7 @@ class ProductApiControllerTest extends ControllerSetUp {
 
         String requestBody = objectMapper.writeValueAsString(requestMap);
 
-        given(productService.create(any(ProductCreateRequest.class), any(User.class)))
+        given(productService.create(any(ProductCreateRequest.class), any(Long.class)))
             .willReturn(1L);
 
         //when
@@ -113,7 +112,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         ResultActions response = mockMvc.perform(request);
 
         //then
-        verify(productService).create(any(ProductCreateRequest.class), any(User.class));
+        verify(productService).create(any(ProductCreateRequest.class), any(Long.class));
         response.andExpect(status().isCreated())
                 .andDo(document("Create product",
                                 preprocessRequest(prettyPrint()),

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -9,9 +9,9 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -20,11 +20,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.Category;
-import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.user.entity.Group;
 import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultProductServiceTest {
@@ -34,6 +35,9 @@ class DefaultProductServiceTest {
 
   @Mock
   private ProductRepository productRepository;
+
+  @Mock
+  private UserService userService;
 
   @Nested
   @DisplayName("findById 메소드는")
@@ -120,6 +124,7 @@ class DefaultProductServiceTest {
                                                                            Category.ETC,
                                                                            15000,
                                                                            "강남");
+      final Long userId = 1L;
       User writer = new User("제로", "image", "google", "1234", new Group());
 
       Product product = Product.builder()
@@ -135,9 +140,10 @@ class DefaultProductServiceTest {
 
       given(productRepository.save(any(Product.class)))
           .willReturn(product);
+      given(userService.findById(userId)).willReturn(writer);
 
       //when
-      long productId = productService.create(productCreateRequest, writer);
+      long productId = productService.create(productCreateRequest, userId);
 
       //then
       verify(productRepository).save(any(Product.class));
@@ -152,16 +158,16 @@ class DefaultProductServiceTest {
       @DisplayName("IllegalArgumentException 에러를 발생시킨다")
       void ItThrowsIllegalArgumentException() {
         //given
-        User writer = new User("제로", "image", "google", "123", new Group());
+        final Long userId = 1L;
 
         //when,then
         assertThrows(IllegalArgumentException.class,
-                     () -> productService.create(null, writer));
+                     () -> productService.create(null, userId));
       }
     }
 
     @Nested
-    @DisplayName("writer 파라미터에 null 값이 전달되면")
+    @DisplayName("userId 파라미터에 null 값이 전달되면")
     class ContextWithWriterNull {
 
       @Test

--- a/src/test/java/com/saiko/bidmarket/util/WithMockCustomLoginUser.java
+++ b/src/test/java/com/saiko/bidmarket/util/WithMockCustomLoginUser.java
@@ -1,0 +1,11 @@
+package com.saiko.bidmarket.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomLoginUserSecurityContextFactory.class)
+public @interface WithMockCustomLoginUser {
+}

--- a/src/test/java/com/saiko/bidmarket/util/WithMockCustomLoginUserSecurityContextFactory.java
+++ b/src/test/java/com/saiko/bidmarket/util/WithMockCustomLoginUserSecurityContextFactory.java
@@ -1,0 +1,34 @@
+package com.saiko.bidmarket.util;
+
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+import com.saiko.bidmarket.common.jwt.JwtAuthenticationToken;
+
+public class WithMockCustomLoginUserSecurityContextFactory
+    implements WithSecurityContextFactory<WithMockCustomLoginUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomLoginUser annotation) {
+
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+    final String token = "mockToken";
+    final Long userId = 1L;
+    final List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    JwtAuthenticationToken authentication =
+        new JwtAuthenticationToken(new JwtAuthentication(token, userId), null,
+                                   authorities);
+
+    securityContext.setAuthentication(authentication);
+
+    return securityContext;
+  }
+}


### PR DESCRIPTION
이번 PR은 두 가지 내용이있습니다

많지 않아서 합쳤어요 (파일 개수만 많지 코드 변경은 적어요!) 많다 싶으면 코멘트 남겨주세요 다음 PR시 양조절 하겠습니다!

### 1. 기존 코드에선 Token에 유저 ID를 넣을 때 StringType으로 넣었었는데 Long으로 넣어도 잘 동작되는걸 확인하고 Long Type으로 변경했습니다

확인 결과 
![image](https://user-images.githubusercontent.com/57293011/181861757-412d23ad-4dda-404b-beaa-270bf50fddbe.png)

---

### 2. 기존에 하영님이 만드신 product create 메서드(Controller, Service)를 토큰에서 받은 userId 정보로 동작하도록 변경했습니다.

## 컨트롤러, 테스트에서 유저 정보를 받는 코드

**컨트롤러  : `@AuthenticationPrincipal JwtAuthentication authentication` 을 인자로 받고 `authentication.getUserId`로 접근**

<img width="740" alt="image" src="https://user-images.githubusercontent.com/57293011/181861850-b9312698-5e3d-445e-9f8c-ee9cf0727d8e.png">

**테스트 : 유저 정보를 받는 controller 메서드 테스트시 `@WithMockCustomLoginUser` 추가**

<img width="275" alt="image" src="https://user-images.githubusercontent.com/57293011/181861910-2bee5db0-6b40-4ddd-be37-99645afd489f.png">




