### PR TITLE
[BM-130] :sparkles: 상품 전체 조회 controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.2'
     id 'io.spring.dependency-management' version '1.0.12.RELEASE'
@@ -5,6 +11,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'org.sonarqube' version '3.0'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.saiko'
@@ -49,6 +56,36 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter:1.17.2'
     testImplementation 'org.testcontainers:mysql:1.17.2'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+}
+
+/**
+ * queryDSL 설정 추가
+*/
+
+def querydslDir = "$buildDir/generated/querydsl"
+// JPA 사용 여부와 사용할 경로를 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+// build 시 사용할 sourceSet 추가
+sourceSets {
+    main.java.srcDir querydslDir
+}
+// querydsl 컴파일시 사용할 옵션 설정
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
+}
+// querydsl 이 compileClassPath 를 상속하도록 설정
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {

--- a/src/main/java/com/saiko/bidmarket/product/Sort.java
+++ b/src/main/java/com/saiko/bidmarket/product/Sort.java
@@ -1,0 +1,23 @@
+package com.saiko.bidmarket.product;
+
+import com.querydsl.core.types.Order;
+
+public enum Sort {
+  END_DATE_ASC("expireAt", Order.ASC);
+
+  private final String property;
+  private final Order order;
+
+  Sort(String property, Order order) {
+    this.property = property;
+    this.order = order;
+  }
+
+  public String getProperty() {
+    return property;
+  }
+
+  public Order getOrder() {
+    return order;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
@@ -1,10 +1,14 @@
 package com.saiko.bidmarket.product.controller;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectResponse;
 import com.saiko.bidmarket.product.service.ProductService;
 
 @RestController
@@ -34,6 +40,16 @@ public class ProductApiController {
   ) {
     long productId = productService.create(productCreateRequest, authentication.getUserId());
     return ProductCreateResponse.from(productId);
+  }
+
+  @GetMapping
+  @ResponseStatus(HttpStatus.OK)
+  public List<ProductSelectResponse> findAll(
+      @ModelAttribute @Valid ProductSelectRequest productSelectRequest) {
+    return productService.findAll(productSelectRequest)
+                         .stream()
+                         .map((product) -> ProductSelectResponse.from(product))
+                         .collect(Collectors.toList());
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectRequest.java
@@ -1,0 +1,20 @@
+package com.saiko.bidmarket.product.controller.dto;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import com.saiko.bidmarket.product.Sort;
+
+public class ProductSelectRequest {
+  @PositiveOrZero
+  private int offset;
+  @Positive
+  private int limit;
+  private Sort sort = Sort.END_DATE_ASC;
+
+  public ProductSelectRequest(int offset, int limit, Sort sort) {
+    this.offset = offset;
+    this.limit = limit;
+    this.sort = sort;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectResponse.java
@@ -1,0 +1,72 @@
+package com.saiko.bidmarket.product.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.saiko.bidmarket.product.entity.Image;
+import com.saiko.bidmarket.product.entity.Product;
+
+public class ProductSelectResponse {
+  private final long id;
+  private final String title;
+  private final String image;
+  private final int minimumPrice;
+  private final LocalDateTime expireAt;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+
+  public ProductSelectResponse(long id, String title, String image, int minimumPrice,
+                               LocalDateTime expireAt, LocalDateTime createdAt,
+                               LocalDateTime updatedAt) {
+    this.id = id;
+    this.title = title;
+    this.image = image;
+    this.minimumPrice = minimumPrice;
+    this.expireAt = expireAt;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static ProductSelectResponse from(Product product) {
+    return new ProductSelectResponse(product.getId(), product.getTitle(),
+                                     createImageUrl(product.getImages()),
+                                     product.getMinimumPrice(), product.getExpireAt(),
+                                     product.getCreatedAt(), product.getUpdatedAt());
+  }
+
+  private static String createImageUrl(List<Image> images) {
+    if (images != null && images.size() >= 1) {
+      return images.get(0).getUrl();
+    }
+    return null;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getImage() {
+    return image;
+  }
+
+  public int getMinimumPrice() {
+    return minimumPrice;
+  }
+
+  public LocalDateTime getExpireAt() {
+    return expireAt;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}
+

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectResponse.java
@@ -29,12 +29,12 @@ public class ProductSelectResponse {
 
   public static ProductSelectResponse from(Product product) {
     return new ProductSelectResponse(product.getId(), product.getTitle(),
-                                     createImageUrl(product.getImages()),
+                                     getThumbnailUrl(product.getImages()),
                                      product.getMinimumPrice(), product.getExpireAt(),
                                      product.getCreatedAt(), product.getUpdatedAt());
   }
 
-  private static String createImageUrl(List<Image> images) {
+  private static String getThumbnailUrl(List<Image> images) {
     if (images != null && images.size() >= 1) {
       return images.get(0).getUrl();
     }

--- a/src/main/java/com/saiko/bidmarket/product/entity/Image.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Image.java
@@ -43,6 +43,10 @@ public class Image extends BaseTime {
     this.order = builder.order;
   }
 
+  public String getUrl() {
+    return url;
+  }
+
   public static class Builder {
 
     private Product product;

--- a/src/main/java/com/saiko/bidmarket/product/entity/Product.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Product.java
@@ -107,6 +107,10 @@ public class Product extends BaseTime {
     return expireAt;
   }
 
+  public List<Image> getImages() {
+    return images;
+  }
+
   public static class Builder {
 
     private String title;

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -1,10 +1,13 @@
 package com.saiko.bidmarket.product.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.user.entity.User;
@@ -46,5 +49,9 @@ public class DefaultProductService implements ProductService {
                                    .build();
     return productRepository.save(product).getId();
   }
-}
 
+  @Override
+  public List<Product> findAll(ProductSelectRequest productSelectRequest) {
+    return null;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -1,6 +1,9 @@
 package com.saiko.bidmarket.product.service;
 
+import java.util.List;
+
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductService {
@@ -8,4 +11,6 @@ public interface ProductService {
   Product findById(long id);
 
   long create(ProductCreateRequest productCreateRequest, Long userId);
+
+  List<Product> findAll(ProductSelectRequest productSelectRequest);
 }

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -482,4 +482,148 @@ class ProductApiControllerTest extends ControllerSetUp {
       }
     }
   }
+
+  @Nested
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+      @Test
+      @DisplayName("상품을 조회하고 결과를 반환한다")
+      void ItReturnProductList() throws Exception {
+        //given
+        Product product = Product.builder()
+                                 .title("귤 팔아요")
+                                 .description("맛있어요")
+                                 .category(FOOD)
+                                 .images(Collections.emptyList())
+                                 .location("제주도")
+                                 .minimumPrice(1000)
+                                 .writer(new User("제로", "image", "google", "123", new Group()))
+                                 .build();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        ReflectionTestUtils.setField(product, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(product, "updatedAt", LocalDateTime.now());
+
+        List<Product> products = Arrays.asList(product);
+        given(productService.findAll(any(ProductSelectRequest.class))).willReturn(products);
+
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.get(BASE_URL)
+                                                                                .contentType(
+                                                                                    MediaType.APPLICATION_FORM_URLENCODED)
+                                                                                .queryParam(
+                                                                                    "offset", "1")
+                                                                                .queryParam("limit",
+                                                                                            "1")
+                                                                                .queryParam("sort",
+                                                                                            Sort.END_DATE_ASC.name());
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(productService).findAll(any(ProductSelectRequest.class));
+        response.andExpect(status().isOk())
+                .andDo(document("Select product", preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()), requestParameters(
+                        parameterWithName("offset").description("상품 조회 시작 번호"),
+                        parameterWithName("limit").description("상품 조회 개수"),
+                        parameterWithName("sort").description("상품 정렬 기준")), responseFields(
+                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("상품 식별자"),
+                        fieldWithPath("[].title").type(JsonFieldType.STRING).description("상품 제목"),
+                        fieldWithPath("[].image").type(JsonFieldType.STRING)
+                                                 .description("이미지")
+                                                 .optional(),
+                        fieldWithPath("[].minimumPrice").type(JsonFieldType.NUMBER)
+                                                        .description("최소주문금액"),
+                        fieldWithPath("[].expireAt").type(JsonFieldType.STRING)
+                                                    .description("비딩 종료 시간"),
+                        fieldWithPath("[].createdAt").type(JsonFieldType.STRING)
+                                                     .description("생성 시간"),
+                        fieldWithPath("[].updatedAt").type(JsonFieldType.STRING)
+                                                     .description("수정 시간"))));
+      }
+    }
+
+    @Nested
+    @DisplayName("offset 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberOffset {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String offset = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL).param("offset", offset));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("offset 에 음수가 들어온다면")
+    class ContextNegativeNumberOffset {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL).param("offset", "-1"));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("limit 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberLimit {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String limit = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
+                                                                                 .param("offset",
+                                                                                        "1")
+                                                                                 .param("limit",
+                                                                                        limit));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("limit 에 음수 나 0이 들어온다면")
+    class ContextNegativeOrZeroNumberLimit {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"0", "-1"})
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest(String limit) throws Exception {
+        // given
+        // when
+        ResultActions response = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
+                                                                                 .param("offset",
+                                                                                        "1")
+                                                                                 .param("limit",
+                                                                                        limit));
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+  }
 }

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -7,12 +7,15 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.lang.reflect.Constructor;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -36,9 +40,13 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.product.Sort;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.service.ProductService;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
 import com.saiko.bidmarket.util.ControllerSetUp;
 import com.saiko.bidmarket.util.WithMockCustomLoginUser;
 


### PR DESCRIPTION
* 현재는 기본 정렬 조건으로 "종료 임박 순"으로 구현하였습니다. 하지만 정렬 조건이 추후에 추가 될 수도 있는데 동적 쿼리를 jpql 을 사용하거나 criterial 를 사용해서 짜게 되면 유지보수가 어렵고 코드의 가독성이 너무 떨어지기 때문에 querydsl을 사용하는게 좋을 것 같다고 생각했습니다!
    * Criterial 참고
        * Criterial 사용시 아래 처럼 작성됨
![image](https://user-images.githubusercontent.com/60775067/181875665-12b4c3fc-1216-400f-838d-6029e1f26c97.png)
              * 문자가 아닌 자바코드로 JPQL을 작성할 수 있음
              * JPA 공식 기능
              * 단점: 너무 복잡하고 실용성이 없다.
              * Criterial 대신에 QueryDSL 사용 권장
