### PR TITLE
[BM-143] 상품 상세 조회 응답 변경에 따른 수정사항 반영

### DIFF
--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductDetailResponse.java
@@ -1,8 +1,13 @@
 package com.saiko.bidmarket.product.controller;
 
+import java.nio.file.attribute.FileTime;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import com.saiko.bidmarket.product.controller.dto.ImagBasicResponse;
 import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.dto.UserBasicResponse;
 
 public class ProductDetailResponse {
   private final Long id;
@@ -13,6 +18,8 @@ public class ProductDetailResponse {
   private final String location;
   private final LocalDateTime expireAt;
   private final LocalDateTime createdAt;
+  private final UserBasicResponse writer;
+  private final List<ImagBasicResponse> imageUrls;
 
   public Long getId() {
     return id;
@@ -50,9 +57,17 @@ public class ProductDetailResponse {
     return updatedAt;
   }
 
+  public UserBasicResponse getWriter() {
+    return writer;
+  }
+
+  public List<ImagBasicResponse> getImageUrls() {
+    return imageUrls;
+  }
+
   private final LocalDateTime updatedAt;
-  
-  private ProductDetailResponse(Product product){
+
+  private ProductDetailResponse(Product product) {
     // 생성을 from 함수로만 하도록 제한
     this.id = product.getId();
     this.title = product.getTitle();
@@ -63,6 +78,11 @@ public class ProductDetailResponse {
     this.expireAt = product.getExpireAt();
     this.createdAt = product.getCreatedAt();
     this.updatedAt = product.getUpdatedAt();
+    this.writer = UserBasicResponse.from(product.getWriter());
+    this.imageUrls = product.getImages()
+                            .stream()
+                            .map(ImagBasicResponse::from)
+                            .collect(Collectors.toList());
   }
 
   public static ProductDetailResponse from(Product product) {

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ImagBasicResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ImagBasicResponse.java
@@ -1,0 +1,25 @@
+package com.saiko.bidmarket.product.controller.dto;
+
+import com.saiko.bidmarket.product.entity.Image;
+
+public class ImagBasicResponse {
+  private final String url;
+  private final int order;
+
+  private ImagBasicResponse(String url, int order) {
+    this.url = url;
+    this.order = order;
+  }
+
+  public static ImagBasicResponse from(Image image) {
+    return new ImagBasicResponse(image.getUrl(), image.getOrder());
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public int getOrder() {
+    return order;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/entity/Image.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Image.java
@@ -47,6 +47,10 @@ public class Image extends BaseTime {
     return url;
   }
 
+  public int getOrder() {
+    return order;
+  }
+
   public static class Builder {
 
     private Product product;

--- a/src/main/java/com/saiko/bidmarket/product/entity/Product.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Product.java
@@ -111,6 +111,10 @@ public class Product extends BaseTime {
     return images;
   }
 
+  public User getWriter() {
+    return writer;
+  }
+
   public static class Builder {
 
     private String title;

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -72,4 +72,8 @@ public class User extends BaseTime {
   public Group getGroup() {
     return group;
   }
+
+  public String getProfileImage() {
+    return profileImage;
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/user/entity/dto/UserBasicResponse.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/dto/UserBasicResponse.java
@@ -1,0 +1,35 @@
+package com.saiko.bidmarket.user.entity.dto;
+
+import com.saiko.bidmarket.user.entity.User;
+
+public class UserBasicResponse {
+
+  private final long id;
+  private final String name;
+  private final String profileImageUrl;
+
+  private UserBasicResponse(long id, String name, String profileImageUrl) {
+    this.id = id;
+    this.name = name;
+    this.profileImageUrl = profileImageUrl;
+  }
+
+  public static UserBasicResponse from(User writer) {
+    return new UserBasicResponse(writer.getId(),
+                                 writer.getUsername(),
+                                 writer.getProfileImage());
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getProfileImageUrl() {
+    return profileImageUrl;
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/user/entity/dto/UserBasicResponse.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/dto/UserBasicResponse.java
@@ -3,25 +3,17 @@ package com.saiko.bidmarket.user.entity.dto;
 import com.saiko.bidmarket.user.entity.User;
 
 public class UserBasicResponse {
-
-  private final long id;
   private final String name;
   private final String profileImageUrl;
 
-  private UserBasicResponse(long id, String name, String profileImageUrl) {
-    this.id = id;
+  private UserBasicResponse(String name, String profileImageUrl) {
     this.name = name;
     this.profileImageUrl = profileImageUrl;
   }
 
   public static UserBasicResponse from(User writer) {
-    return new UserBasicResponse(writer.getId(),
-                                 writer.getUsername(),
+    return new UserBasicResponse(writer.getUsername(),
                                  writer.getProfileImage());
-  }
-
-  public long getId() {
-    return id;
   }
 
   public String getName() {

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -472,8 +472,6 @@ class ProductApiControllerTest extends ControllerSetUp {
                                                               .description("생성 시간"),
                                     fieldWithPath("updatedAt").type(JsonFieldType.STRING)
                                                               .description("수정 시간"),
-                                    fieldWithPath("writer.id").type(JsonFieldType.NUMBER)
-                                                              .description("작성자 식별자"),
                                     fieldWithPath("writer.name").type(JsonFieldType.STRING)
                                                                 .description("작성자 이름"),
                                     fieldWithPath("writer.profileImageUrl")

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -32,7 +32,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -409,7 +408,6 @@ class ProductApiControllerTest extends ControllerSetUp {
     class ContextValidId {
 
       @Test
-      @WithAnonymousUser
       @DisplayName("해당 id를 가진 상품의 도메인 객체와 OK로 응답한다.")
       void itResponseOkWithProductDomainObjectHasInputId() throws Exception {
         // given

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -481,8 +481,6 @@ class ProductApiControllerTest extends ControllerSetUp {
                                     fieldWithPath("writer.profileImageUrl")
                                         .type(JsonFieldType.STRING)
                                         .description("작성자 이미지 주소"),
-                                    // fieldWithPath("imageUrls[]").type(JsonFieldType.ARRAY)
-                                    //                           .description("이미지 주소 리스트"),
                                     fieldWithPath("imageUrls[].url").type(JsonFieldType.STRING)
                                                                     .description("이미지 주소"),
                                     fieldWithPath("imageUrls[].order").type(JsonFieldType.NUMBER)


### PR DESCRIPTION
## 상품 상세 조회 응답 변경에 따른 수정
![image](https://user-images.githubusercontent.com/61923768/181903879-f2943ab1-859d-463b-b80c-191f4496643d.png)
- 빨간색 부분이 추가 되었습니다.

- 상품 상세 조회 관련해서 프론트에서 작성자 정보를 추가로 요청하여서 해당 요청 반영
- 상품 객체 변경에 따른 상품 이미지 정보도 응답 객체에 추가

## 변경사항
- 이미지 응답용 객체 정의
- 응답 객체에 작성자와 상품 이미지 주소 리스트 추가
- 불필요한 어노테이션 삭제