### PR TITLE
[BM-141] sql 누락 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
       schema-locations:
         - classpath:sql/product/product_schema.sql
         - classpath:sql/user/user_schema.sql
+        - classpath:sql/user/oauth2_authorized_client.sql
         - classpath:org/springframework/security/oauth2/client/oauth2-client-schema.sql
         - classpath:sql/constraint.sql
       data-locations: classpath:sql/user/user_data.sql


### PR DESCRIPTION
- sql 초기화시 oauth2-client-schema 테이블이 존재하면 drop 하는 로직이 빠져있어 수정하였습니다.
- 운영 데이터가 쌓이면 `drop table if exist` 로 관리하지 말고 flyway를 사용해야 할것같습니다.