### PR TITLE
[BM-142] 회원 정보 수정 Service 메서드 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -61,6 +61,14 @@ public class User extends BaseTime {
     this.group = group;
   }
 
+  public void update(String username, String profileImage) {
+    Assert.notNull(username, "username must be provide");
+    Assert.notNull(profileImage, "profileImage must be provide");
+
+    this.username = username;
+    this.profileImage = profileImage;
+  }
+
   public Long getId() {
     return id;
   }

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -40,7 +40,6 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
-  @Transactional
   public User join(OAuth2User oAuth2User, String authorizedClientRegistrationId) {
     Assert.notNull(oAuth2User, "OAuth2User must be provided");
     Assert.hasText(authorizedClientRegistrationId,
@@ -77,6 +76,9 @@ public class DefaultUserService implements UserService {
 
   @Override
   public void updateUser(long id, UserUpdateRequest request) {
+    Assert.notNull(request, "request must be provide");
 
+    final User user = findById(id);
+    user.update(request.getUsername(), request.getProfileImageUrl());
   }
 }


### PR DESCRIPTION
Service 레이어의 회원 정보 수정 기능 테스트와 프로덕션 코드를 구현했습니다.

- User Entity에 update 메서드를 추가했습니다.
- UserService에 update 메서드를 추가했습니다. 
- 해당 메서드 테스트 코드를 작성했습니다.

entity의 update 메서드에서 인자 검증 의미가 있는 검증일까요?