### PR TITLE
[BM-179] findAllUserProduct QueryDSL 메서드 작성

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
+++ b/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
@@ -4,6 +4,7 @@ package com.saiko.bidmarket.common.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -50,6 +51,12 @@ public class ExceptionController {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleIllegalArgumentException(IllegalArgumentException e) {
     logger.warn("IllegalArgumentException : ", e);
+  }
+
+  @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleInvalidDataAccessApiUsageException(InvalidDataAccessApiUsageException e) {
+    logger.warn("InvalidDataAccessApiUsageException : ", e);
   }
 
   @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepository.java
@@ -8,4 +8,6 @@ import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductCustomRepository {
   List<Product> findAllProduct(Pageable pageable);
+
+  List<Product> findAllUserProduct(long userId, Pageable pageable);
 }

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepositoryImpl.java
@@ -2,12 +2,14 @@ package com.saiko.bidmarket.product.repository;
 
 import static com.saiko.bidmarket.product.Sort.*;
 import static com.saiko.bidmarket.product.entity.QProduct.*;
+import static com.saiko.bidmarket.user.entity.QUser.*;
 
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
@@ -32,6 +34,19 @@ public class ProductCustomRepositoryImpl
         .limit(pageable.getPageSize())
         .orderBy(getOrderSpecifier(pageable.getSort()))
         .fetch();
+  }
+
+  @Override
+  public List<Product> findAllUserProduct(long userId, Pageable pageable) {
+    Assert.isTrue(userId > 0, "User id must be positive");
+    Assert.notNull(pageable, "Page must be provided");
+    return jpaQueryFactory.selectFrom(product)
+                          .join(product.writer, user)
+                          .where(user.id.eq(userId))
+                          .offset(pageable.getOffset())
+                          .limit(pageable.getPageSize())
+                          .orderBy(getOrderSpecifier(pageable.getSort()))
+                          .fetch();
   }
 
   private OrderSpecifier getOrderSpecifier(Sort sort) {

--- a/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
@@ -7,10 +7,13 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
@@ -90,6 +93,90 @@ public class ProductRepositoryTest {
         assertThat(result.size()).isEqualTo(2);
         assertThat(result.get(0)).isEqualTo(product1);
         assertThat(result.get(1)).isEqualTo(product2);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("findAllUserProduct 메소드는")
+  class DescribeFindAllUserProduct {
+
+    @Nested
+    @DisplayName("정상적인 값이 들어오면")
+    class ContextValidData {
+
+      @Test
+      @DisplayName("해당 유저가 판매한, 페이징 처리된 상품 목록을 반환한다")
+      void itReturnProductList() {
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 2, Sort.Direction.ASC, "expireAt");
+
+        Group group = groupRepository.findById(1L).get();
+
+        User writer1 = new User("제로", "image", "google", "123", group);
+        User writer2 = new User("재이", "image", "google", "1234", group);
+
+        writer1 = userRepository.save(writer1);
+        writer2 = userRepository.save(writer2);
+
+        Product product1 = productRepository.save(
+            Product.builder()
+                   .title("노트북 팝니다1")
+                   .description("싸요")
+                   .category(Category.DIGITAL_DEVICE)
+                   .minimumPrice(10000)
+                   .images(null)
+                   .location(null)
+                   .writer(writer1)
+                   .build()
+        );
+
+        Product product2 = productRepository.save(
+            Product.builder()
+                   .title("노트북 팝니다2")
+                   .description("싸요")
+                   .category(Category.DIGITAL_DEVICE)
+                   .minimumPrice(10000)
+                   .images(null)
+                   .location(null)
+                   .writer(writer2)
+                   .build()
+        );
+
+        // when
+        List<Product> result = productRepository.findAllUserProduct(writer1.getId(), pageRequest);
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo(product1);
+      }
+    }
+
+    @Nested
+    @DisplayName("userId 가 양수가 아닌 값이 전달되면")
+    class ContextWithNotPositiveUserId {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1L, Long.MIN_VALUE})
+      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
+      void ItThrowsInvalidDataAccessApiUsageException(long src) {
+        PageRequest pageRequest = PageRequest.of(0, 2, Sort.Direction.ASC, "expireAt");
+        //when, then
+        assertThatThrownBy(() -> productRepository.findAllUserProduct(src, pageRequest))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("PageRequest 가 null 이면")
+    class ContextWithNullPageRequest {
+
+      @Test
+      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
+      void ItThrowsInvalidDataAccessApiUsageException() {
+        //when, then
+        assertThatThrownBy(() -> productRepository.findAllUserProduct(1L, null))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class);
       }
     }
   }


### PR DESCRIPTION
## 주요사항
- 유저가 판매한 상품목록을 조회하는 QueryDSL 메서드를 작성하였습니다.
- 상품목록에 유저의 정보는 불필요하므로 inner join으로 작성하였습니다.

```
Hibernate: 
    select
        product0_.id as id1_7_,
        product0_.created_at as created_2_7_,
        product0_.updated_at as updated_3_7_,
        product0_.category as category4_7_,
        product0_.description as descript5_7_,
        product0_.expire_at as expire_a6_7_,
        product0_.location as location7_7_,
        product0_.minimum_price as minimum_8_7_,
        product0_.thumbnail_image as thumbnai9_7_,
        product0_.title as title10_7_,
        product0_.user_id as user_id11_7_ 
    from
        product product0_ 
    inner join
        `user` user1_ 
            on product0_.user_id=user1_.id 
    where
        user1_.id=? 
    order by
        product0_.expire_at asc limit ?
```

- Assertion 을 통해 검증하였을때 IllegalArgumentException 이 발생하여야 하는데 QueryDSL 이 InvalidDataAccessApiUsageException 으로 감싸서 에러를 발생시키는것같습니다. 이부분은 ControllerAdvice에 반영하였습니다.