### PR TITLE
[BM-176] :sparkles: 상품 검색 api 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
+++ b/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
@@ -1,11 +1,11 @@
 package com.saiko.bidmarket.common.exception;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -33,6 +33,12 @@ public class ExceptionController {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleConversionFailedException(ConversionFailedException e) {
     logger.warn("ConversionFailedException : ", e);
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public void handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    logger.warn("HttpMessageNotReadableException : ", e);
   }
 
   @ExceptionHandler(NumberFormatException.class)

--- a/src/main/java/com/saiko/bidmarket/product/Category.java
+++ b/src/main/java/com/saiko/bidmarket/product/Category.java
@@ -1,6 +1,5 @@
 package com.saiko.bidmarket.product;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Category {
@@ -29,16 +28,6 @@ public enum Category {
   @JsonValue
   public String getDisplayName() {
     return displayName;
-  }
-
-  @JsonCreator
-  public static Category from(String name) {
-    for (Category category : Category.values()) {
-      if (category.getDisplayName().equals(name)) {
-        return category;
-      }
-    }
-    return null;
   }
 }
 

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductSelectRequest.java
@@ -3,22 +3,29 @@ package com.saiko.bidmarket.product.controller.dto;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
+import com.saiko.bidmarket.product.Category;
 import com.saiko.bidmarket.product.Sort;
 
 public class ProductSelectRequest {
+  private final Category category;
   @PositiveOrZero
-  private int offset;
+  private final int offset;
   @Positive
-  private int limit;
+  private final int limit;
   private Sort sort;
 
-  public ProductSelectRequest(int offset, int limit, Sort sort) {
+  public ProductSelectRequest(Category category, int offset, int limit, Sort sort) {
+    this.category = category;
     this.offset = offset;
     this.limit = limit;
     this.sort = sort;
     if (sort == null) {
       this.sort = Sort.END_DATE_ASC;
     }
+  }
+
+  public Category getCategory() {
+    return category;
   }
 
   public int getOffset() {

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepository.java
@@ -2,12 +2,9 @@ package com.saiko.bidmarket.product.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
-
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductCustomRepository {
-  List<Product> findAllProduct(Pageable pageable);
-
-  List<Product> findAllUserProduct(long userId, Pageable pageable);
+  List<Product> findAllProduct(ProductSelectRequest productSelectRequest);
 }

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductCustomRepositoryImpl.java
@@ -2,19 +2,19 @@ package com.saiko.bidmarket.product.repository;
 
 import static com.saiko.bidmarket.product.Sort.*;
 import static com.saiko.bidmarket.product.entity.QProduct.*;
-import static com.saiko.bidmarket.user.entity.QUser.*;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.entity.Product;
 
 @Repository
@@ -27,36 +27,29 @@ public class ProductCustomRepositoryImpl
   }
 
   @Override
-  public List<Product> findAllProduct(Pageable pageable) {
+  public List<Product> findAllProduct(ProductSelectRequest productSelectRequest) {
+    Assert.notNull(productSelectRequest, "ProductSelectRequest must be provided");
     return jpaQueryFactory
         .selectFrom(product)
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .orderBy(getOrderSpecifier(pageable.getSort()))
+        .where(eqCategory(productSelectRequest.getCategory()))
+        .offset(productSelectRequest.getOffset())
+        .limit(productSelectRequest.getLimit())
+        .orderBy(getOrderSpecifier(productSelectRequest.getSort()))
         .fetch();
   }
 
-  @Override
-  public List<Product> findAllUserProduct(long userId, Pageable pageable) {
-    Assert.isTrue(userId > 0, "User id must be positive");
-    Assert.notNull(pageable, "Page must be provided");
-    return jpaQueryFactory.selectFrom(product)
-                          .join(product.writer, user)
-                          .where(user.id.eq(userId))
-                          .offset(pageable.getOffset())
-                          .limit(pageable.getPageSize())
-                          .orderBy(getOrderSpecifier(pageable.getSort()))
-                          .fetch();
+  private Predicate eqCategory(Category category) {
+    if (category == null) {
+      return null;
+    }
+    return product.category.eq(category);
   }
 
-  private OrderSpecifier getOrderSpecifier(Sort sort) {
-    for (Sort.Order order : sort) {
-      String property = order.getProperty();
-      if (property.equals(END_DATE_ASC.getProperty())) {
-        Path<Object> fieldPath = Expressions.path(Object.class, product,
-                                                  END_DATE_ASC.getProperty());
-        return new OrderSpecifier(END_DATE_ASC.getOrder(), fieldPath);
-      }
+  private OrderSpecifier getOrderSpecifier(com.saiko.bidmarket.product.Sort sort) {
+    if (sort == END_DATE_ASC) {
+      Path<Object> fieldPath = Expressions.path(Object.class, product,
+                                                END_DATE_ASC.getProperty());
+      return new OrderSpecifier(END_DATE_ASC.getOrder(), fieldPath);
     }
     return null;
   }

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -1,12 +1,14 @@
 package com.saiko.bidmarket.product.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.product.controller.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
@@ -54,9 +56,8 @@ public class DefaultProductService implements ProductService {
   }
 
   @Override
-  public List<Product> findAll(ProductSelectRequest productSelectRequest) {
+  public List<ProductSelectResponse> findAll(ProductSelectRequest productSelectRequest) {
     Assert.notNull(productSelectRequest, "ProductSelectRequest must be provided");
-    return productRepository.findAllProduct(productSelectRequest);
     return productRepository.findAllProduct(productSelectRequest).stream()
                             .map(ProductSelectResponse::from)
                             .collect(Collectors.toList());

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -1,16 +1,12 @@
 package com.saiko.bidmarket.product.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
-import com.saiko.bidmarket.product.controller.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
@@ -58,18 +54,10 @@ public class DefaultProductService implements ProductService {
   }
 
   @Override
-  public List<ProductSelectResponse> findAll(ProductSelectRequest productSelectRequest) {
-    Assert.notNull(productSelectRequest, "Request must be provided");
-
-    PageRequest pageRequest = PageRequest.of(productSelectRequest.getOffset(),
-                                             productSelectRequest.getLimit(),
-                                             Sort.Direction.valueOf(
-                                                 productSelectRequest.getSort()
-                                                                     .getOrder()
-                                                                     .toString()),
-                                             productSelectRequest.getSort().getProperty());
-
-    return productRepository.findAllProduct(pageRequest).stream()
+  public List<Product> findAll(ProductSelectRequest productSelectRequest) {
+    Assert.notNull(productSelectRequest, "ProductSelectRequest must be provided");
+    return productRepository.findAllProduct(productSelectRequest);
+    return productRepository.findAllProduct(productSelectRequest).stream()
                             .map(ProductSelectResponse::from)
                             .collect(Collectors.toList());
   }

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -101,7 +101,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
+        requestMap.put("category", DIGITAL_DEVICE);
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});
@@ -158,7 +158,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", title);
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
+        requestMap.put("category", DIGITAL_DEVICE);
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});
@@ -190,7 +190,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", description);
-        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
+        requestMap.put("category", DIGITAL_DEVICE);
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("imageUrl1", new String[]{"imageUrl1, imageUrl2"});
@@ -221,7 +221,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
+        requestMap.put("category", DIGITAL_DEVICE);
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", Arrays.asList("imageUrl1",
@@ -257,7 +257,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE.getDisplayName());
+        requestMap.put("category", DIGITAL_DEVICE);
         requestMap.put("minimumPrice", 100);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("imageUrl1", new String[]{"imageUrl1, imageUrl2"});

--- a/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.saiko.bidmarket.common.config.QueryDslConfig;
@@ -39,6 +40,19 @@ public class ProductRepositoryTest {
   @Nested
   @DisplayName("findAllProduct 메소드는")
   class DescribeFindAllProduct {
+
+    @Nested
+    @DisplayName("ProductSelectRequest 가 null 이라면")
+    class ContextWithProductSelectRequestNull {
+
+      @Test
+      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
+      void ItThrowsInvalidDataAccessApiUsageException() {
+        //when, then
+        assertThatThrownBy(() -> productRepository.findAllProduct(null))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class);
+      }
+    }
 
     @Nested
     @DisplayName("카테고리 정보가 안넘어온다면")

--- a/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
@@ -7,15 +7,10 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.saiko.bidmarket.common.config.QueryDslConfig;
@@ -46,23 +41,15 @@ public class ProductRepositoryTest {
   class DescribeFindAllProduct {
 
     @Nested
-    @DisplayName("정상적인 값이 들어오면")
+    @DisplayName("카테고리 정보가 안넘어온다면")
     class ContextValidData {
 
       @Test
-      @DisplayName("페이징 처리된 상품 목록을 반환한다")
+      @DisplayName("페이징 처리된 전체 카테고리 상품 목록을 반환한다")
       void itReturnProductList() {
         // given
-        ProductSelectRequest productSelectRequest = new ProductSelectRequest(0, 2,
+        ProductSelectRequest productSelectRequest = new ProductSelectRequest(null, 0, 2,
                                                                              com.saiko.bidmarket.product.Sort.END_DATE_ASC);
-        PageRequest pageRequest = PageRequest.of(productSelectRequest.getOffset(),
-                                                 productSelectRequest.getLimit(),
-                                                 Sort.Direction.valueOf(
-                                                     productSelectRequest.getSort()
-                                                                         .getOrder()
-                                                                         .toString()),
-                                                 productSelectRequest.getSort().getProperty());
-
         Group group = groupRepository.findById(1L).get();
         User writer = new User("제로", "image", "google", "123", group);
         writer = userRepository.save(writer);
@@ -87,7 +74,7 @@ public class ProductRepositoryTest {
                                                          .build());
 
         // when
-        List<Product> result = productRepository.findAllProduct(pageRequest);
+        List<Product> result = productRepository.findAllProduct(productSelectRequest);
 
         // then
         assertThat(result.size()).isEqualTo(2);
@@ -95,88 +82,47 @@ public class ProductRepositoryTest {
         assertThat(result.get(1)).isEqualTo(product2);
       }
     }
-  }
-
-  @Nested
-  @DisplayName("findAllUserProduct 메소드는")
-  class DescribeFindAllUserProduct {
 
     @Nested
-    @DisplayName("정상적인 값이 들어오면")
-    class ContextValidData {
+    @DisplayName("카테고리가 넘어온다면")
+    class ContextWithCategoryFilter {
 
       @Test
-      @DisplayName("해당 유저가 판매한, 페이징 처리된 상품 목록을 반환한다")
-      void itReturnProductList() {
+      @DisplayName("페이징 처리된 특정 카테고리 상품 목록을 반환한다")
+      void itReturnCategoryProductList() {
         // given
-        PageRequest pageRequest = PageRequest.of(0, 2, Sort.Direction.ASC, "expireAt");
-
+        ProductSelectRequest productSelectRequest = new ProductSelectRequest(
+            Category.DIGITAL_DEVICE, 0, 2,
+            com.saiko.bidmarket.product.Sort.END_DATE_ASC);
         Group group = groupRepository.findById(1L).get();
+        User writer = new User("제로", "image", "google", "123", group);
+        writer = userRepository.save(writer);
 
-        User writer1 = new User("제로", "image", "google", "123", group);
-        User writer2 = new User("재이", "image", "google", "1234", group);
-
-        writer1 = userRepository.save(writer1);
-        writer2 = userRepository.save(writer2);
-
-        Product product1 = productRepository.save(
-            Product.builder()
-                   .title("노트북 팝니다1")
-                   .description("싸요")
-                   .category(Category.DIGITAL_DEVICE)
-                   .minimumPrice(10000)
-                   .images(null)
-                   .location(null)
-                   .writer(writer1)
-                   .build()
-        );
-
-        Product product2 = productRepository.save(
-            Product.builder()
-                   .title("노트북 팝니다2")
-                   .description("싸요")
-                   .category(Category.DIGITAL_DEVICE)
-                   .minimumPrice(10000)
-                   .images(null)
-                   .location(null)
-                   .writer(writer2)
-                   .build()
-        );
+        Product product1 = productRepository.save(Product.builder()
+                                                         .title("노트북 팝니다1")
+                                                         .description("싸요")
+                                                         .category(Category.DIGITAL_DEVICE)
+                                                         .minimumPrice(10000)
+                                                         .images(null)
+                                                         .location(null)
+                                                         .writer(writer)
+                                                         .build());
+        productRepository.save(Product.builder()
+                                      .title("화분")
+                                      .description("예뻐요")
+                                      .category(Category.PLANT)
+                                      .minimumPrice(10000)
+                                      .images(null)
+                                      .location(null)
+                                      .writer(writer)
+                                      .build());
 
         // when
-        List<Product> result = productRepository.findAllUserProduct(writer1.getId(), pageRequest);
+        List<Product> result = productRepository.findAllProduct(productSelectRequest);
 
         // then
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0)).isEqualTo(product1);
-      }
-    }
-
-    @Nested
-    @DisplayName("userId 가 양수가 아닌 값이 전달되면")
-    class ContextWithNotPositiveUserId {
-
-      @ParameterizedTest
-      @ValueSource(longs = {0, -1L, Long.MIN_VALUE})
-      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
-      void ItThrowsInvalidDataAccessApiUsageException(long src) {
-        PageRequest pageRequest = PageRequest.of(0, 2, Sort.Direction.ASC, "expireAt");
-        //when, then
-        assertThatThrownBy(() -> productRepository.findAllUserProduct(src, pageRequest))
-            .isInstanceOf(InvalidDataAccessApiUsageException.class);
-      }
-    }
-
-    @Nested
-    @DisplayName("PageRequest 가 null 이면")
-    class ContextWithNullPageRequest {
-
-      @Test
-      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
-      void ItThrowsInvalidDataAccessApiUsageException() {
-        //when, then
-        assertThatThrownBy(() -> productRepository.findAllUserProduct(1L, null))
-            .isInstanceOf(InvalidDataAccessApiUsageException.class);
       }
     }
   }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -156,7 +156,7 @@ class DefaultProductServiceTest {
       @DisplayName("요청에 해당하는 상품 리스트를 반환한다")
       void ItResponseProductList() {
         //given
-        ProductSelectRequest productSelectRequest = new ProductSelectRequest(0, 2, null);
+        ProductSelectRequest productSelectRequest = new ProductSelectRequest(null, 0, 2, null);
         User writer = new User("제로", "image", "google", "1234", new Group());
         Product product = Product.builder()
                                  .title("세탁기 팔아요")
@@ -178,7 +178,7 @@ class DefaultProductServiceTest {
         //then
         verify(productRepository).findAllProduct(any(ProductSelectRequest.class));
         assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0)).isEqualTo(product);
+        assertThat(result.get(0).getId()).isEqualTo(product.getId());
       }
     }
   }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
@@ -130,7 +129,6 @@ class DefaultProductServiceTest {
         assertThat(response.getId()).isEqualTo(product.getId());
       }
     }
-
   }
 
   @Nested
@@ -171,15 +169,16 @@ class DefaultProductServiceTest {
                                  .build();
         ReflectionTestUtils.setField(product, "id", 1L);
 
-        given(productRepository.findAllProduct(any(PageRequest.class)))
+        given(productRepository.findAllProduct(any(ProductSelectRequest.class)))
             .willReturn(List.of(product));
 
         //when
         List<ProductSelectResponse> result = productService.findAll(productSelectRequest);
 
         //then
-        verify(productRepository).findAllProduct(any(PageRequest.class));
+        verify(productRepository).findAllProduct(any(ProductSelectRequest.class));
         assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo(product);
       }
     }
   }
@@ -250,6 +249,5 @@ class DefaultProductServiceTest {
         assertThat(response.getId()).isEqualTo(product.getId());
       }
     }
-
   }
 }


### PR DESCRIPTION
## 기능 구현
* 전체 조회와 구현이 똑같아서 동일한 컨트롤러(/api/v1/products)로 요청 보내도록 했습니다. 
* 우선 카테고리 검색 & 종료 임박순 정렬 구현하였습니다. 필요한 부분은 추후에 기능 추가하면 될 것 같습니다.
* 카테고리 정보가 넘어오지 않는다면 전체 카테고리 상품 목록을 조회합니다.

## 요청 결과
* 카테고리 추가 안함
![스크린샷 2022-08-02 오후 5 21 41](https://user-images.githubusercontent.com/60775067/182330332-df67cabe-d47d-4469-9e87-c349b7b2fdf6.png)
```java
Hibernate: 
    select
        product0_.id as id1_7_,
        product0_.created_at as created_2_7_,
        product0_.updated_at as updated_3_7_,
        product0_.category as category4_7_,
        product0_.description as descript5_7_,
        product0_.expire_at as expire_a6_7_,
        product0_.location as location7_7_,
        product0_.minimum_price as minimum_8_7_,
        product0_.thumbnail_image as thumbnai9_7_,
        product0_.title as title10_7_,
        product0_.user_id as user_id11_7_ 
    from
        product product0_ 
    order by
        product0_.expire_at asc limit ?
```

* 카테고리 포함 검색
![스크린샷 2022-08-02 오후 5 22 17](https://user-images.githubusercontent.com/60775067/182330843-9b5f1f68-a836-4c7c-bc31-8fe8efc87af3.png)
```java
Hibernate: 
    select
        product0_.id as id1_7_,
        product0_.created_at as created_2_7_,
        product0_.updated_at as updated_3_7_,
        product0_.category as category4_7_,
        product0_.description as descript5_7_,
        product0_.expire_at as expire_a6_7_,
        product0_.location as location7_7_,
        product0_.minimum_price as minimum_8_7_,
        product0_.thumbnail_image as thumbnai9_7_,
        product0_.title as title10_7_,
        product0_.user_id as user_id11_7_ 
    from
        product product0_ 
    where
        product0_.category=? 
    order by
        product0_.expire_at asc limit ?
```
## 일부 수정 사항
* 기존에는 프론트에서 카테고리 정보를 한글 이름(디지털 기기) 으로 보내주기로 되어있었는데 한글 이름으로 요청을 보낼 경우 url 에 공백이나 "/" 포함되는 문제가 있어서 프론트와 이야기 하여 영어 이름(HOUSEHOLD_APPLIANCE)으로 보내주기로 수정했습니다. 