### PR TITLE
[BM-186] 유저 판매 내역 조회 Controller 구현입니다.

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -110,6 +110,7 @@ public class WebSecurityConfig {
 
     http.authorizeRequests()
         .antMatchers(HttpMethod.POST, "/api/v1/products").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.GET, "/api/v1/users/products").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()
         /**

--- a/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
@@ -1,10 +1,13 @@
 package com.saiko.bidmarket.user.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +16,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserUpdateRequest;
 import com.saiko.bidmarket.user.service.UserService;
@@ -40,5 +45,15 @@ public class UserApiController {
   @ResponseStatus(HttpStatus.OK)
   public UserSelectResponse getUser(@PathVariable long id) {
     return userService.findById(id);
+  }
+
+  @GetMapping("products")
+  @ResponseStatus(HttpStatus.OK)
+  public List<UserProductSelectResponse> getAllUserProduct(
+      @AuthenticationPrincipal JwtAuthentication authentication,
+      @ModelAttribute @Valid UserProductSelectRequest request
+  ) {
+    long userId = authentication.getUserId();
+    return userService.findAllUserProducts(userId, request);
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/controller/dto/UserProductSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/dto/UserProductSelectRequest.java
@@ -1,0 +1,28 @@
+package com.saiko.bidmarket.user.controller.dto;
+
+import static com.saiko.bidmarket.product.Sort.*;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import com.saiko.bidmarket.product.Sort;
+
+import lombok.Getter;
+
+@Getter
+public class UserProductSelectRequest {
+
+  @PositiveOrZero
+  private final int offset;
+
+  @Positive
+  private final int limit;
+
+  private final Sort sort;
+
+  public UserProductSelectRequest(int offset, int limit, Sort sort) {
+    this.offset = offset;
+    this.limit = limit;
+    this.sort = sort != null ? sort : END_DATE_ASC;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/user/controller/dto/UserProductSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/dto/UserProductSelectResponse.java
@@ -1,0 +1,36 @@
+package com.saiko.bidmarket.user.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.saiko.bidmarket.product.controller.dto.ProductSelectResponse;
+import com.saiko.bidmarket.product.entity.Product;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserProductSelectResponse {
+
+  private final long id;
+
+  private final String title;
+
+  private final String thumbnailImage;
+
+  private final int minimumPrice;
+
+  private final LocalDateTime expireAt;
+
+  private final LocalDateTime createdAt;
+
+  private final LocalDateTime updatedAt;
+
+  public static UserProductSelectResponse from(Product product) {
+    return new UserProductSelectResponse(product.getId(), product.getTitle(),
+                                     product.getThumbnailImage(),
+                                     product.getMinimumPrice(), product.getExpireAt(),
+                                     product.getCreatedAt(), product.getUpdatedAt());
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -1,5 +1,6 @@
 package com.saiko.bidmarket.user.service;
 
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserUpdateRequest;
 import com.saiko.bidmarket.user.entity.Group;
@@ -84,5 +87,11 @@ public class DefaultUserService implements UserService {
                                     .orElseThrow(
                                         () -> new NotFoundException("User does not exist"));
     user.update(request.getUsername(), request.getProfileImageUrl());
+  }
+
+  @Override
+  public List<UserProductSelectResponse> findAllUserProducts(long userId,
+                                                             UserProductSelectRequest request) {
+    return null;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/service/UserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/UserService.java
@@ -1,7 +1,11 @@
 package com.saiko.bidmarket.user.service;
 
+import java.util.List;
+
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
+import com.saiko.bidmarket.user.controller.dto.UserProductSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserUpdateRequest;
 import com.saiko.bidmarket.user.entity.User;
@@ -14,4 +18,6 @@ public interface UserService {
   UserSelectResponse findById(long id);
 
   void updateUser(long id, UserUpdateRequest request);
+
+  List<UserProductSelectResponse> findAllUserProducts(long userId, UserProductSelectRequest request);
 }


### PR DESCRIPTION
```
Response
[
	{
		"id": Number,
		"title": String,
		"thumbnailImage": String,
		"minimumPrice": Number,
		"expireAt": Date,
		"createdAt": Date,
		"updatedAt": Date,
	},
	{} // 유사 데이터 limit 개수만큼 반환
]	
```