### PR TITLE
[BM-67] 경매 종료 스케줄러 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
@@ -27,19 +27,10 @@ public class ScheduledConfig {
     @Scheduled(cron = "0 * * * * *")
     public void closeProduct() {
       LocalDateTime now = LocalDateTime.now();
-      LocalDateTime start = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
+      LocalDateTime nowTime = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
                                              now.getHour(), now.getMinute());
 
-      LocalDateTime end;
-      if (now.getMinute() != 59) {
-        end = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
-                               now.getHour(), now.getMinute() + 1);
-      } else {
-        end = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
-                               now.getHour() + 1, 0);
-      }
-
-      List<Product> productsInProgress = productService.findAllThatNeedToClose(start, end);
+      List<Product> productsInProgress = productService.findAllThatNeedToClose(nowTime);
       if (productsInProgress.size() != 0) {
         productService.executeClosingProduct(productsInProgress);
       }

--- a/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
@@ -1,18 +1,48 @@
 package com.saiko.bidmarket.common.config;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.product.service.ProductService;
+
 @Configuration
 @EnableScheduling
 public class ScheduledConfig {
+
+  private final ProductService productService;
+
+  public ScheduledConfig(ProductService productService) {
+    this.productService = productService;
+  }
+
   @Component
   public class Scheduler {
 
     @Scheduled(cron = "0 * * * * *")
-    public void checkAuctionState() {
+    public void closeProduct() {
+      LocalDateTime now = LocalDateTime.now();
+      LocalDateTime start = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
+                                             now.getHour(), now.getMinute());
+
+      LocalDateTime end;
+      if (now.getMinute() != 59) {
+        end = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
+                               now.getHour(), now.getMinute() + 1);
+      } else {
+        end = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
+                               now.getHour() + 1, 0);
+      }
+
+      List<Product> productsInProgress = productService.findAllThatNeedToClose(start, end);
+      if (productsInProgress.size() != 0) {
+        productService.executeClosingProduct(productsInProgress);
+      }
     }
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductRepository.java
@@ -1,8 +1,14 @@
 package com.saiko.bidmarket.product.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductRepository extends ProductCustomRepository, JpaRepository<Product, Long> {
+
+  List<Product> findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
+      boolean progressed, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/saiko/bidmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/saiko/bidmarket/product/repository/ProductRepository.java
@@ -9,6 +9,5 @@ import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductRepository extends ProductCustomRepository, JpaRepository<Product, Long> {
 
-  List<Product> findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
-      boolean progressed, LocalDateTime start, LocalDateTime end);
+  List<Product> findAllByProgressedAndExpireAtLessThan(boolean progressed, LocalDateTime nowTime);
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -74,12 +74,10 @@ public class DefaultProductService implements ProductService {
   }
 
   @Override
-  public List<Product> findAllThatNeedToClose(LocalDateTime start, LocalDateTime end) {
-    Assert.notNull(start, "Start must be provided");
-    Assert.notNull(end, "End must be provided");
+  public List<Product> findAllThatNeedToClose(LocalDateTime nowTime) {
+    Assert.notNull(nowTime, "nowTime must be provided");
 
-    return productRepository.findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
-        false, start, end);
+    return productRepository.findAllByProgressedAndExpireAtLessThan(false, nowTime);
   }
 
   @Override

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -1,5 +1,6 @@
 package com.saiko.bidmarket.product.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,5 +71,19 @@ public class DefaultProductService implements ProductService {
     return ProductDetailResponse.from(productRepository.findById(id)
                                                        .orElseThrow(() -> new NotFoundException(
                                                            "Product not exist")));
+  }
+
+  @Override
+  public List<Product> findAllThatNeedToClose(LocalDateTime start, LocalDateTime end) {
+    Assert.notNull(start, "Start must be provided");
+    Assert.notNull(end, "End must be provided");
+
+    return productRepository.findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
+        false, start, end);
+  }
+
+  @Override
+  public void executeClosingProduct(List<Product> products) {
+    // TODO: 경매 종료시 수행되는 비즈니스 로직 구현
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.saiko.bidmarket.product.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.saiko.bidmarket.product.controller.ProductDetailResponse;
@@ -7,6 +8,7 @@ import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectResponse;
+import com.saiko.bidmarket.product.entity.Product;
 
 public interface ProductService {
   ProductCreateResponse create(ProductCreateRequest productCreateRequest, Long userId);
@@ -14,4 +16,8 @@ public interface ProductService {
   List<ProductSelectResponse> findAll(ProductSelectRequest productSelectRequest);
 
   ProductDetailResponse findById(long id);
+
+  List<Product> findAllThatNeedToClose(LocalDateTime start, LocalDateTime end);
+
+  void executeClosingProduct(List<Product> productsInProgress);
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -17,7 +17,7 @@ public interface ProductService {
 
   ProductDetailResponse findById(long id);
 
-  List<Product> findAllThatNeedToClose(LocalDateTime start, LocalDateTime end);
+  List<Product> findAllThatNeedToClose(LocalDateTime nowTime);
 
   void executeClosingProduct(List<Product> productsInProgress);
 }

--- a/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
@@ -60,15 +60,14 @@ public class SchedulerTest {
                                  .build();
         ReflectionTestUtils.setField(product, "id", 1L);
 
-        BDDMockito.given(productService.findAllThatNeedToClose(any(), any()))
-                  .willReturn(List.of(product));
+        BDDMockito.given(productService.findAllThatNeedToClose(any())).willReturn(List.of(product));
 
         // when, then
         await()
             .atMost(Duration.ofMinutes(1))
             .untilAsserted(() -> {
               verify(scheduler, atLeast(1)).closeProduct();
-              verify(productService).findAllThatNeedToClose(any(), any());
+              verify(productService).findAllThatNeedToClose(any());
               verify(productService).executeClosingProduct(any());
             });
       }
@@ -82,7 +81,7 @@ public class SchedulerTest {
       @DisplayName("경매 종료 로직을 실행하지 않는다.")
       void ItDoesNotExecuteClosingProduct() {
         // given
-        BDDMockito.given(productService.findAllThatNeedToClose(any(), any())).willReturn(
+        BDDMockito.given(productService.findAllThatNeedToClose(any())).willReturn(
             Collections.emptyList());
 
         // when, then
@@ -90,7 +89,7 @@ public class SchedulerTest {
             .atMost(Duration.ofMinutes(1))
             .untilAsserted(() -> {
               verify(scheduler, atLeast(1)).closeProduct();
-              verify(productService).findAllThatNeedToClose(any(), any());
+              verify(productService).findAllThatNeedToClose(any());
               verify(productService, times(0)).executeClosingProduct(any());
             });
       }

--- a/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
@@ -1,38 +1,99 @@
 package com.saiko.bidmarket.product;
 
+import static com.saiko.bidmarket.product.Category.*;
 import static org.awaitility.Awaitility.*;
 import static org.mockito.BDDMockito.atLeast;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.config.ScheduledConfig;
 import com.saiko.bidmarket.common.config.ScheduledConfig.Scheduler;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.product.service.ProductService;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
 
 @SpringJUnitConfig(ScheduledConfig.class)
 public class SchedulerTest {
   @SpyBean
   private Scheduler scheduler;
 
+  @MockBean
+  private ProductService productService;
+
   @Nested
-  @DisplayName("스케줄러는")
-  class DescribeScheduler {
+  @DisplayName("1분마다 동작하는 closeProduct 메소드는")
+  class DescribeCloseProduct {
 
-    @Test
-    @DisplayName("1분마다 CheckAuctionState 메서드를 호출한다")
-    void ItCallCheckAuctionStateMethodEveryMinute() {
-      // given
+    @Nested
+    @DisplayName("해당 시간에 종료되어야 할 경매들이 존재한다면")
+    class ContextWithProductsThatNeedToClose {
 
-      // when, then
-      await()
-          .atMost(Duration.ofMinutes(1))
-          .untilAsserted(() -> verify(scheduler, atLeast(1)).checkAuctionState());
+      @Test
+      @DisplayName("경매 종료 로직을 실행한다.")
+      void ItExecuteClosingProduct() {
+        // given
+        User writer = new User("제로", "image", "google", "1234", new Group());
+        ReflectionTestUtils.setField(writer, "id", 1L);
+        Product product = Product.builder()
+                                 .title("텀블러 팝니다")
+                                 .description("깨끗해요")
+                                 .location("강남")
+                                 .category(ETC)
+                                 .minimumPrice(15000)
+                                 .images(Arrays.asList("image1",
+                                                       "image2"))
+                                 .writer(writer)
+                                 .build();
+        ReflectionTestUtils.setField(product, "id", 1L);
+
+        BDDMockito.given(productService.findAllThatNeedToClose(any(), any()))
+                  .willReturn(List.of(product));
+
+        // when, then
+        await()
+            .atMost(Duration.ofMinutes(1))
+            .untilAsserted(() -> {
+              verify(scheduler, atLeast(1)).closeProduct();
+              verify(productService).findAllThatNeedToClose(any(), any());
+              verify(productService).executeClosingProduct(any());
+            });
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 시간에 종료되어야 할 경매들이 존재하지 않는다면")
+    class ContextWithNotExistedProducts {
+
+      @Test
+      @DisplayName("경매 종료 로직을 실행하지 않는다.")
+      void ItDoesNotExecuteClosingProduct() {
+        // given
+        BDDMockito.given(productService.findAllThatNeedToClose(any(), any())).willReturn(
+            Collections.emptyList());
+
+        // when, then
+        await()
+            .atMost(Duration.ofMinutes(1))
+            .untilAsserted(() -> {
+              verify(scheduler, atLeast(1)).closeProduct();
+              verify(productService).findAllThatNeedToClose(any(), any());
+              verify(productService, times(0)).executeClosingProduct(any());
+            });
+      }
     }
   }
 }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -257,27 +257,14 @@ class DefaultProductServiceTest {
   class DescribeFindAllThatNeedToClose {
 
     @Nested
-    @DisplayName("start가 null 이면")
+    @DisplayName("nowTime이 null 이면")
     class ContextWithNullStart {
 
       @Test
       @DisplayName("IllegalArgumentException 예외를 던진다")
       void ItThrowsIllegalArgumentException() {
         //when, then
-        assertThatThrownBy(() -> productService.findAllThatNeedToClose(null, LocalDateTime.now()))
-            .isInstanceOf(IllegalArgumentException.class);
-      }
-    }
-
-    @Nested
-    @DisplayName("end가 null 이면")
-    class ContextWithNullEnd {
-
-      @Test
-      @DisplayName("IllegalArgumentException 예외를 던진다")
-      void ItThrowsIllegalArgumentException() {
-        //when, then
-        assertThatThrownBy(() -> productService.findAllThatNeedToClose(LocalDateTime.now(), null))
+        assertThatThrownBy(() -> productService.findAllThatNeedToClose(null))
             .isInstanceOf(IllegalArgumentException.class);
       }
     }
@@ -301,17 +288,14 @@ class DefaultProductServiceTest {
                                  .images(null)
                                  .build();
         ReflectionTestUtils.setField(product, "id", 1L);
-        given(productRepository.findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
-            anyBoolean(), any(LocalDateTime.class), any(LocalDateTime.class))).willReturn(
-            List.of(product));
+        given(productRepository.findAllByProgressedAndExpireAtLessThan(
+            anyBoolean(), any(LocalDateTime.class))).willReturn(List.of(product));
 
         //when
-        List<Product> result = productService.findAllThatNeedToClose(
-            LocalDateTime.now(), LocalDateTime.now().plusMinutes(1));
+        List<Product> result = productService.findAllThatNeedToClose(LocalDateTime.now());
 
         //then
-        verify(productRepository).findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
-            anyBoolean(), any(), any());
+        verify(productRepository).findAllByProgressedAndExpireAtLessThan(anyBoolean(), any());
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getId()).isEqualTo(product.getId());
       }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -4,6 +4,7 @@ import static com.saiko.bidmarket.product.Category.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -247,6 +248,72 @@ class DefaultProductServiceTest {
 
         //then
         assertThat(response.getId()).isEqualTo(product.getId());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("findAllThatNeedToClose 메서드는")
+  class DescribeFindAllThatNeedToClose {
+
+    @Nested
+    @DisplayName("start가 null 이면")
+    class ContextWithNullStart {
+
+      @Test
+      @DisplayName("IllegalArgumentException 예외를 던진다")
+      void ItThrowsIllegalArgumentException() {
+        //when, then
+        assertThatThrownBy(() -> productService.findAllThatNeedToClose(null, LocalDateTime.now()))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("end가 null 이면")
+    class ContextWithNullEnd {
+
+      @Test
+      @DisplayName("IllegalArgumentException 예외를 던진다")
+      void ItThrowsIllegalArgumentException() {
+        //when, then
+        assertThatThrownBy(() -> productService.findAllThatNeedToClose(LocalDateTime.now(), null))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidArgument {
+
+      @Test
+      @DisplayName("요청에 해당하는 상품 리스트를 반환한다")
+      void ItResponseProductList() {
+        //when, then
+        User writer = new User("제로", "image", "google", "1234", new Group());
+        Product product = Product.builder()
+                                 .title("세탁기 팔아요")
+                                 .description("좋아요")
+                                 .minimumPrice(100000)
+                                 .category(HOUSEHOLD_APPLIANCE)
+                                 .location("수원")
+                                 .writer(writer)
+                                 .images(null)
+                                 .build();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        given(productRepository.findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
+            anyBoolean(), any(LocalDateTime.class), any(LocalDateTime.class))).willReturn(
+            List.of(product));
+
+        //when
+        List<Product> result = productService.findAllThatNeedToClose(
+            LocalDateTime.now(), LocalDateTime.now().plusMinutes(1));
+
+        //then
+        verify(productRepository).findAllByProgressedAndExpireAtGreaterThanEqualAndExpireAtLessThan(
+            anyBoolean(), any(), any());
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getId()).isEqualTo(product.getId());
       }
     }
   }


### PR DESCRIPTION
매 분마다 해당 시간에 종료되는 경매가 있는지 확인하고, 있다면 경매 종료 로직을 수행하도록 하는 스케줄러를 구현하였습니다.
경매 종료 백엔드 로직에 해당하는 것은 다음 PR 때 올라올 예정입니다.