### PR TITLE
[BM-190] 상품 상세 조회 API 변경 사항 반영

### DIFF
--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectResponse;
 import com.saiko.bidmarket.product.service.ProductService;

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductDetailResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductDetailResponse.java
@@ -20,7 +20,9 @@ public class ProductDetailResponse {
   private final String description;
 
   private final int minimumPrice;
-  private final String categoryName;
+
+  private final Category category;
+
   private final String location;
 
   private final LocalDateTime expireAt;
@@ -31,35 +33,7 @@ public class ProductDetailResponse {
 
   private final UserBasicResponse writer;
 
-  public String getCategoryName() {
-    return categoryName;
-  }
-
-  public String getLocation() {
-    return location;
-  }
-
-  public LocalDateTime getExpireAt() {
-    return expireAt;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
-  }
-
-  public UserBasicResponse getWriter() {
-    return writer;
-  }
-
-  public List<ImagBasicResponse> getImageUrls() {
-    return imageUrls;
-  }
-
-  private final LocalDateTime updatedAt;
+  private final List<ImagBasicResponse> images;
 
   private ProductDetailResponse(Product product) {
     // 생성을 from 함수로만 하도록 제한
@@ -67,16 +41,16 @@ public class ProductDetailResponse {
     this.title = product.getTitle();
     this.description = product.getDescription();
     this.minimumPrice = product.getMinimumPrice();
-    this.categoryName = product.getCategory().getDisplayName();
+    this.category = product.getCategory();
     this.location = product.getLocation();
     this.expireAt = product.getExpireAt();
     this.createdAt = product.getCreatedAt();
     this.updatedAt = product.getUpdatedAt();
     this.writer = UserBasicResponse.from(product.getWriter());
-    this.imageUrls = product.getImages()
-                            .stream()
-                            .map(ImagBasicResponse::from)
-                            .collect(Collectors.toList());
+    this.images = product.getImages()
+                         .stream()
+                         .map(ImagBasicResponse::from)
+                         .collect(Collectors.toList());
   }
 
   public static ProductDetailResponse from(Product product) {

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductDetailResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/ProductDetailResponse.java
@@ -1,40 +1,35 @@
-package com.saiko.bidmarket.product.controller;
+package com.saiko.bidmarket.product.controller.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.saiko.bidmarket.product.controller.dto.ImagBasicResponse;
+import com.saiko.bidmarket.product.Category;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.entity.dto.UserBasicResponse;
 
+import lombok.Getter;
+
+@Getter
 public class ProductDetailResponse {
+
   private final Long id;
+
   private final String title;
+
   private final String description;
+
   private final int minimumPrice;
   private final String categoryName;
   private final String location;
+
   private final LocalDateTime expireAt;
+
   private final LocalDateTime createdAt;
+
+  private final LocalDateTime updatedAt;
+
   private final UserBasicResponse writer;
-  private final List<ImagBasicResponse> imageUrls;
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public int getMinimumPrice() {
-    return minimumPrice;
-  }
 
   public String getCategoryName() {
     return categoryName;

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
-import com.saiko.bidmarket.product.controller.ProductDetailResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -2,7 +2,7 @@ package com.saiko.bidmarket.product.service;
 
 import java.util.List;
 
-import com.saiko.bidmarket.product.controller.ProductDetailResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saiko.bidmarket.product.Sort;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectResponse;
 import com.saiko.bidmarket.product.entity.Image;

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -444,8 +444,8 @@ class ProductApiControllerTest extends ControllerSetUp {
                                                                 .description("상품 소개"),
                                     fieldWithPath("minimumPrice").type(JsonFieldType.NUMBER)
                                                                  .description("최소주문금액"),
-                                    fieldWithPath("categoryName").type(JsonFieldType.STRING)
-                                                                 .description("카테고리 이름"),
+                                    fieldWithPath("category").type(JsonFieldType.STRING)
+                                                             .description("카테고리 이름"),
                                     fieldWithPath("location").type(JsonFieldType.STRING)
                                                              .description("거래 위치"),
                                     fieldWithPath("expireAt").type(JsonFieldType.STRING)
@@ -459,10 +459,10 @@ class ProductApiControllerTest extends ControllerSetUp {
                                     fieldWithPath("writer.profileImageUrl")
                                         .type(JsonFieldType.STRING)
                                         .description("작성자 이미지 주소"),
-                                    fieldWithPath("imageUrls[].url").type(JsonFieldType.STRING)
-                                                                    .description("이미지 주소"),
-                                    fieldWithPath("imageUrls[].order").type(JsonFieldType.NUMBER)
-                                                                      .description("이미지 순서")
+                                    fieldWithPath("images[].url").type(JsonFieldType.STRING)
+                                                                 .description("이미지 주소"),
+                                    fieldWithPath("images[].order").type(JsonFieldType.NUMBER)
+                                                                   .description("이미지 순서")
                                 )
                 ));
       }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.exception.NotFoundException;
-import com.saiko.bidmarket.product.controller.ProductDetailResponse;
+import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductSelectRequest;


### PR DESCRIPTION
### 주요 내용
- 상품 상세 조회 응답 객체의 필드명 변경 (프론트 요청 사항)
  - categoryName ⇒ category
  - imageUrls ⇒ images
- 상세 조회 응답 dto가 dto 패키지가 아니라 밖에 있어서 이동
- 응답 객체에 롬복 getter 적용