### PR TITLE
[BM-191] 비딩 상품 진행 상태 검증 로직 추가

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/controller/BiddingController.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/controller/BiddingController.java
@@ -19,7 +19,7 @@ import com.saiko.bidmarket.common.entity.UnsignedLong;
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 
 @RestController
-@RequestMapping("api/v1/bidding")
+@RequestMapping("api/v1/biddings")
 public class BiddingController {
 
   private final BiddingService biddingService;

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -38,6 +38,10 @@ public class DefaultBiddingService implements BiddingService {
     Product product = productRepository.findById(createDto.getProductId().getValue())
                                        .orElseThrow(NotFoundException::new);
 
+    if (!product.isProgressed()) {
+      throw new IllegalArgumentException("비딩이 종료된 상품에 비딩할 수 없습니다.");
+    }
+
     Bidding bidding = new Bidding(createDto.getBiddingPrice(), bidder, product);
 
     Bidding createdBidding = biddingRepository.save(bidding);

--- a/src/test/java/com/saiko/bidmarket/bidding/controller/BiddingControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/controller/BiddingControllerTest.java
@@ -47,7 +47,7 @@ class BiddingControllerTest extends ControllerSetUp {
   @MockBean
   private BiddingService biddingService;
 
-  public static final String BASE_URL = "/api/v1/bidding";
+  public static final String BASE_URL = "/api/v1/biddings";
 
   static class BiddingPriceSourceOutOfRange implements ArgumentsProvider {
 

--- a/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
@@ -106,6 +106,35 @@ class DefaultBiddingServiceTest {
             .isInstanceOf(NotFoundException.class);
       }
     }
+    
+    @Nested
+    @DisplayName("해당 상품의 비딩이 종료되었다면")
+    class ContextExpiredProduct {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 발생시킨다.")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        BiddingPrice biddingPrice = BiddingPrice.valueOf(1000L);
+        UnsignedLong productId = UnsignedLong.valueOf(1);
+        UnsignedLong bidderId = UnsignedLong.valueOf(1);
+        BiddingCreateDto createDto = BiddingCreateDto.builder()
+                                                     .biddingPrice(biddingPrice)
+                                                     .bidderId(bidderId)
+                                                     .productId(productId)
+                                                     .build();
+
+        ReflectionTestUtils.setField(product, "progressed", false);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(bidder));
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+
+        // when
+        // then
+        assertThatThrownBy(() -> biddingService.create(createDto))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
 
     @Nested
     @DisplayName("BiddingCreateDto의 bidder Id에 해당하는 사용자가 없으면")
@@ -149,6 +178,8 @@ class DefaultBiddingServiceTest {
                                                      .bidderId(bidderId)
                                                      .productId(productId)
                                                      .build();
+
+        ReflectionTestUtils.setField(product, "progressed", true);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(bidder));
         given(productRepository.findById(anyLong())).willReturn(Optional.of(product));


### PR DESCRIPTION
### 주요 사항
- 비딩 시 상품의 진행 상태를 검증하는 로직 및 테스트 추가
  - `product.isProgressed() ` 활용하여 진행하지 않을 경우 비딩되지 않도록 하였습니다.
- 비딩 api path 복수형으로 변경