### PR TITLE
[BM-193] 경매 종료 스케줄러 테스트 시간 수정

### DIFF
--- a/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/SchedulerTest.java
@@ -64,7 +64,7 @@ public class SchedulerTest {
 
         // when, then
         await()
-            .atMost(Duration.ofMinutes(1))
+            .atMost(Duration.ofSeconds(119))
             .untilAsserted(() -> {
               verify(scheduler, atLeast(1)).closeProduct();
               verify(productService).findAllThatNeedToClose(any());
@@ -86,7 +86,7 @@ public class SchedulerTest {
 
         // when, then
         await()
-            .atMost(Duration.ofMinutes(1))
+            .atMost(Duration.ofSeconds(119))
             .untilAsserted(() -> {
               verify(scheduler, atLeast(1)).closeProduct();
               verify(productService).findAllThatNeedToClose(any());


### PR DESCRIPTION
`.atMost(Duration.ofSeconds(119))` : 60초 -> 119초로 변경하였습니다.