### PR TITLE
[BM-189] :sparkles: 입찰 목록 조회 service, repository 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingCustomRepository.java
@@ -1,0 +1,10 @@
+package com.saiko.bidmarket.bidding.respository;
+
+import java.util.List;
+
+import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
+
+public interface BiddingCustomRepository {
+  List<Bidding> findAllUserBidding(long userId, UserBiddingSelectRequest request);
+}

--- a/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingCustomRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.saiko.bidmarket.bidding.respository;
+
+import static com.saiko.bidmarket.bidding.entity.QBidding.*;
+import static com.saiko.bidmarket.product.Sort.*;
+import static com.saiko.bidmarket.product.entity.QProduct.*;
+import static com.saiko.bidmarket.user.entity.QUser.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
+
+@Repository
+public class BiddingCustomRepositoryImpl
+    implements BiddingCustomRepository {
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public BiddingCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+    this.jpaQueryFactory = jpaQueryFactory;
+  }
+
+  @Override
+  public List<Bidding> findAllUserBidding(long userId, UserBiddingSelectRequest request) {
+    Assert.isTrue(userId > 0, "User id must be positive");
+    Assert.notNull(request, "Request must be provided");
+
+    return jpaQueryFactory
+        .selectFrom(bidding)
+        .join(bidding.product, product).fetchJoin()
+        .join(bidding.bidder, user).fetchJoin()
+        .where(bidding.bidder.id.eq(userId))
+        .offset(request.getOffset())
+        .limit(request.getLimit())
+        .orderBy(getOrderSpecifier(request.getSort()))
+        .fetch();
+  }
+
+  private OrderSpecifier getOrderSpecifier(com.saiko.bidmarket.product.Sort sort) {
+    if (sort == END_DATE_ASC) {
+      Path<Object> fieldPath = Expressions.path(Object.class, product,
+                                                END_DATE_ASC.getProperty());
+      return new OrderSpecifier(END_DATE_ASC.getOrder(), fieldPath);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingRepository.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.saiko.bidmarket.bidding.entity.Bidding;
 import com.saiko.bidmarket.product.entity.Product;
 
-public interface BiddingRepository extends JpaRepository<Bidding, Long> {
+public interface BiddingRepository extends BiddingCustomRepository, JpaRepository<Bidding, Long> {
   List<Bidding> findAllByProductOrderByBiddingPriceDesc(Product product);
 }

--- a/src/main/java/com/saiko/bidmarket/product/Category.java
+++ b/src/main/java/com/saiko/bidmarket/product/Category.java
@@ -1,5 +1,6 @@
 package com.saiko.bidmarket.product;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Category {
@@ -23,6 +24,16 @@ public enum Category {
 
   Category(String displayName) {
     this.displayName = displayName;
+  }
+
+  @JsonCreator
+  public static Category from(String name) {
+    for (Category category : Category.values()) {
+      if (category.name().equals(name)) {
+        return category;
+      }
+    }
+    return null;
   }
 
   @JsonValue

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -120,8 +120,9 @@ public class DefaultUserService implements UserService {
     Assert.notNull(request, "Request must be provided");
 
     return biddingRepository.findAllUserBidding(userId, request)
-                            .stream().map((bidding) -> bidding.getProduct())
-                            .map((product) -> UserBiddingSelectResponse.from(product))
+                            .stream()
+                            .map((bidding) -> bidding.getProduct())
+                            .map(UserBiddingSelectResponse::from)
                             .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.bidding.respository.BiddingRepository;
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.product.repository.dto.UserProductSelectQueryParameter;
@@ -35,6 +36,7 @@ public class DefaultUserService implements UserService {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final ProductRepository productRepository;
+  private final BiddingRepository biddingRepository;
   private final UserRepository userRepository;
   private final GroupService groupService;
 
@@ -114,6 +116,12 @@ public class DefaultUserService implements UserService {
   @Override
   public List<UserBiddingSelectResponse> findAllUserBiddings(long userId,
                                                              UserBiddingSelectRequest request) {
-    return null;
+    Assert.isTrue(userId > 0, "User id must be positive");
+    Assert.notNull(request, "Request must be provided");
+
+    return biddingRepository.findAllUserBidding(userId, request)
+                            .stream().map((bidding) -> bidding.getProduct())
+                            .map((product) -> UserBiddingSelectResponse.from(product))
+                            .collect(Collectors.toList());
   }
 }

--- a/src/main/resources/sql/bidding/bidding_schema.sql
+++ b/src/main/resources/sql/bidding/bidding_schema.sql
@@ -2,11 +2,11 @@ DROP TABLE IF EXISTS `bidding` CASCADE;
 
 CREATE TABLE `bidding`
 (
-    id              bigint       not null,
-    bidding_price   bigint       not null,
-    won             tinyint(1)   not null,
-    created_at      timestamp    not null,
-    updated_at      timestamp    not null,
-    bidder_id       bigint       not null,
-    product_id      bigint       not null
+    id            bigint     not null,
+    bidding_price bigint     not null,
+    won           tinyint(1) not null,
+    created_at    timestamp  not null,
+    updated_at    timestamp,
+    bidder_id     bigint     not null,
+    product_id    bigint     not null
 );

--- a/src/test/java/com/saiko/bidmarket/bidding/repository/BiddingRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/repository/BiddingRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.saiko.bidmarket.bidding.repository;
+
+import static com.saiko.bidmarket.product.Sort.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.bidding.entity.BiddingPrice;
+import com.saiko.bidmarket.bidding.respository.BiddingRepository;
+import com.saiko.bidmarket.common.config.QueryDslConfig;
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.product.repository.ProductRepository;
+import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.GroupRepository;
+import com.saiko.bidmarket.user.repository.UserRepository;
+
+@DataJpaTest()
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value = QueryDslConfig.class)
+public class BiddingRepositoryTest {
+  @Autowired
+  private BiddingRepository biddingRepository;
+
+  @Autowired
+  private GroupRepository groupRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @Nested
+  @DisplayName("findAllUserBidding 메소드는")
+  class DescribeFindAllUserBidding {
+
+    @Nested
+    @DisplayName("UserBiddingSelectRequest 가 null 이라면")
+    class ContextWithUserBiddingSelectRequestNull {
+
+      @Test
+      @DisplayName("InvalidDataAccessApiUsageException 에러를 발생시킨다")
+      void ItThrowsInvalidDataAccessApiUsageException() {
+        //when, then
+        assertThatThrownBy(() -> biddingRepository.findAllUserBidding(1, null))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("userId 가 양수가 아니면")
+    class ContextWithUserIdNotPositive {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1L, Long.MIN_VALUE})
+      @DisplayName("InvalidDataAccessApiUsageException 예외를 던진다")
+      void ItThrowsInvalidDataAccessApiUsageException(long src) {
+        //given
+        UserBiddingSelectRequest request = new UserBiddingSelectRequest(0, 1, END_DATE_ASC);
+
+        //when, then
+        assertThatThrownBy(() -> biddingRepository.findAllUserBidding(src, request))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("올바른 정보가 넘어온다면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("페이징 처리된 입찰 상품 목록을 반환한다")
+      void itReturnBiddingProductList() {
+        // given
+        Group group = groupRepository.findById(1L).get();
+
+        User writer = userRepository.save(User.builder()
+                                              .username("제로")
+                                              .profileImage("image")
+                                              .provider("google")
+                                              .providerId("123")
+                                              .group(group)
+                                              .build());
+        User bidder = userRepository.save(User.builder()
+                                              .username("레이")
+                                              .profileImage("image")
+                                              .provider("google")
+                                              .providerId("321")
+                                              .group(group)
+                                              .build());
+
+        Product product = productRepository.save(Product.builder()
+                                                        .title("노트북 팝니다1")
+                                                        .description("싸요")
+                                                        .category(Category.DIGITAL_DEVICE)
+                                                        .minimumPrice(10000)
+                                                        .images(null)
+                                                        .location(null)
+                                                        .writer(writer)
+                                                        .build());
+
+        Bidding bidding = biddingRepository.save(Bidding.builder()
+                                                        .bidder(bidder)
+                                                        .product(product)
+                                                        .biddingPrice(BiddingPrice.valueOf(1000))
+                                                        .build());
+
+        UserBiddingSelectRequest userBiddingSelectRequest = new UserBiddingSelectRequest(0, 1,
+                                                                                         END_DATE_ASC);
+        // when
+        List<Bidding> result = biddingRepository.findAllUserBidding(bidder.getId(),
+                                                                    userBiddingSelectRequest);
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo(bidding);
+      }
+    }
+  }
+}

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -102,7 +102,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", "DIGITAL_DEVICE");
+        requestMap.put("category", DIGITAL_DEVICE.name());
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -102,7 +102,7 @@ class ProductApiControllerTest extends ControllerSetUp {
         HashMap<String, Object> requestMap = new HashMap<>();
         requestMap.put("title", "키보드팝니다");
         requestMap.put("description", "깨끗합니다");
-        requestMap.put("category", DIGITAL_DEVICE);
+        requestMap.put("category", "DIGITAL_DEVICE");
         requestMap.put("minimumPrice", 10000);
         requestMap.put("location", "관악구 신림동");
         requestMap.put("images", new String[]{"imageUrl1, imageUrl2"});

--- a/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/repository/ProductRepositoryTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.config.QueryDslConfig;
 import com.saiko.bidmarket.product.Category;
@@ -162,7 +161,6 @@ public class ProductRepositoryTest {
 
         User writer = new User("박동철", "image", "google", "1234", group);
         writer = userRepository.save(writer);
-        ReflectionTestUtils.setField(writer, "id", 1L);
 
         Product product = productRepository.save(
             Product.builder()


### PR DESCRIPTION
## 구현 사항
* 입찰 목록 조회 service, repository 구현 하였습니다.

### 동작 확인
<img width="1007" alt="스크린샷 2022-08-03 오후 6 55 15" src="https://user-images.githubusercontent.com/60775067/182582103-9c4613d8-e7a6-43c8-8e27-edfa84389772.png">

```java
Hibernate: 
    select
        bidding0_.id as id1_0_0_,
        product1_.id as id1_7_1_,
        user2_.id as id1_8_2_,
        bidding0_.created_at as created_2_0_0_,
        bidding0_.updated_at as updated_3_0_0_,
        bidding0_.`bidder_id` as bidder_i5_0_0_,
        bidding0_.bidding_price as bidding_4_0_0_,
        bidding0_.product_id as product_6_0_0_,
        product1_.created_at as created_2_7_1_,
        product1_.updated_at as updated_3_7_1_,
        product1_.category as category4_7_1_,
        product1_.description as descript5_7_1_,
        product1_.expire_at as expire_a6_7_1_,
        product1_.location as location7_7_1_,
        product1_.minimum_price as minimum_8_7_1_,
        product1_.progressed as progress9_7_1_,
        product1_.thumbnail_image as thumbna10_7_1_,
        product1_.title as title11_7_1_,
        product1_.user_id as user_id12_7_1_,
        user2_.created_at as created_2_8_2_,
        user2_.updated_at as updated_3_8_2_,
        user2_.group_id as group_id8_8_2_,
        user2_.profile_image as profile_4_8_2_,
        user2_.provider as provider5_8_2_,
        user2_.provider_id as provider6_8_2_,
        user2_.username as username7_8_2_ 
    from
        bidding bidding0_ 
    inner join
        product product1_ 
            on bidding0_.product_id=product1_.id 
    inner join
        `user` user2_ 
            on bidding0_.`bidder_id`=user2_.id 
    where
        bidding0_.`bidder_id`=? 
    order by
        product1_.expire_at asc limit ?
```

## 기존 코드 수정 사항
* bidding 스키마에서 created_at, updated_at null 허용으로 변경하였습니다.
* category enum에 @JsonCreator를 지우니 요청 dto 바인딩에서 문제가 생겨 category enum에 @JsonCreator 추가했습니다.
