### PR TITLE
[BM-187] 경매 종료 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
@@ -39,6 +39,8 @@ public class Bidding extends BaseTime {
   @ManyToOne(fetch = FetchType.EAGER)
   private Product product;
 
+  private boolean won;
+
   @Builder
   public Bidding(BiddingPrice biddingPrice, User bidder, Product product) {
     Assert.notNull(biddingPrice, "Bidding price must be provided");
@@ -48,6 +50,10 @@ public class Bidding extends BaseTime {
     this.biddingPrice = biddingPrice.getValue();
     this.bidder = bidder;
     this.product = product;
+    this.won = false;
   }
 
+  public void win() {
+    this.won = true;
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingRepository.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/respository/BiddingRepository.java
@@ -1,8 +1,12 @@
 package com.saiko.bidmarket.bidding.respository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.product.entity.Product;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
+  List<Bidding> findAllByProductOrderByBiddingPriceDesc(Product product);
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
@@ -2,8 +2,11 @@ package com.saiko.bidmarket.bidding.service;
 
 import com.saiko.bidmarket.bidding.service.dto.BiddingCreateDto;
 import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.product.entity.Product;
 
 public interface BiddingService {
 
   UnsignedLong create(BiddingCreateDto createDto);
+
+  long selectWinner(Product product);
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -1,5 +1,7 @@
 package com.saiko.bidmarket.bidding.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -47,5 +49,22 @@ public class DefaultBiddingService implements BiddingService {
     Bidding createdBidding = biddingRepository.save(bidding);
 
     return UnsignedLong.valueOf(createdBidding.getId());
+  }
+
+  @Override
+  public long selectWinner(Product product) {
+    Assert.notNull(product, "product must be provided");
+
+    List<Bidding> biddings = biddingRepository.findAllByProductOrderByBiddingPriceDesc(product);
+
+    //TODO: 비딩한 내역이 존재하지 않는 Product일 경우 로직 구현
+
+    biddings.get(0).win();
+
+    if (biddings.size() == 1) {
+      return product.getMinimumPrice();
+    }
+
+    return biddings.get(1).getBiddingPrice() + 1000L;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/entity/Product.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Product.java
@@ -59,6 +59,8 @@ public class Product extends BaseTime {
 
   private boolean progressed;
 
+  private long winningPrice;
+
   @NotNull
   private LocalDateTime expireAt;
 
@@ -111,6 +113,15 @@ public class Product extends BaseTime {
       return null;
     }
     return imageUrls.get(0);
+  }
+
+  public void finish(long winningPrice) {
+    this.progressed = false;
+    setWinningPrice(winningPrice);
+  }
+
+  private void setWinningPrice(long winningPrice) {
+    this.winningPrice = winningPrice;
   }
 }
 

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.bidding.service.BiddingService;
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
@@ -27,11 +28,15 @@ public class DefaultProductService implements ProductService {
 
   private final UserRepository userRepository;
 
+  private final BiddingService biddingService;
+
   public DefaultProductService(
       ProductRepository productRepository,
-      UserRepository userRepository) {
+      UserRepository userRepository,
+      BiddingService biddingService) {
     this.userRepository = userRepository;
     this.productRepository = productRepository;
+    this.biddingService = biddingService;
   }
 
   @Override
@@ -82,6 +87,13 @@ public class DefaultProductService implements ProductService {
 
   @Override
   public void executeClosingProduct(List<Product> products) {
-    // TODO: 경매 종료시 수행되는 비즈니스 로직 구현
+    if (products.isEmpty()) {
+      throw new IllegalArgumentException("products must be provided");
+    }
+
+    for (Product product : products) {
+      long winningPrice = biddingService.selectWinner(product);
+      product.finish(winningPrice);
+    }
   }
 }

--- a/src/main/resources/sql/bidding/bidding_schema.sql
+++ b/src/main/resources/sql/bidding/bidding_schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE `bidding`
 (
     id              bigint       not null,
     bidding_price   bigint       not null,
+    won             tinyint(1)   not null,
     created_at      timestamp    not null,
     updated_at      timestamp    not null,
     bidder_id       bigint       not null,

--- a/src/main/resources/sql/product/product_schema.sql
+++ b/src/main/resources/sql/product/product_schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE `product`
     location        varchar(100),
     thumbnail_image varchar(512),
     progressed      tinyint(1)   not null,
+    winning_price   bigint,
     expire_at       timestamp    not null,
     created_at      timestamp,
     updated_at      timestamp,


### PR DESCRIPTION
# 구현 내용
* 경매 종료시 수행되는 비즈니스 로직을 구현하였습니다.
* 기획서에 작성된 내용은 다음과 같습니다.
  * ![image](https://user-images.githubusercontent.com/78195316/182621627-31927099-bc0d-41f6-afdc-bdb8a3428e4c.png)


* 경매 종료시 로직 흐름은 다음과 같습니다.
  1. Bidding 상태값 변경
  2.  최고 가격을 제시한 Bidder가 낙찰
    * 낙찰 가격 =  2등 입찰 가격 + 1000원
    * 입찰자가 한 명이라면 최소 금액(minimumPrice)으로 낙찰
  3. Product 경매 상품 상태값 변경

# 논의해야 할 부분
* 경매에 입찰한 입찰자가 한 명도 존재하지 않을 경우의 로직은 구현하지 않았습니다. (`DefaultBiddingService` 클래스 내부 메소드에 주석 처리해 둠)
* 내일 기획 논의 후 기능 추가하도록 하겠습니다.