### PR TITLE
[BM-182] 사용자의 판매 상품 내역 조회 security 설정 제거 

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -110,7 +110,6 @@ public class WebSecurityConfig {
 
     http.authorizeRequests()
         .antMatchers(HttpMethod.POST, "/api/v1/products").hasAnyRole("USER", "ADMIN")
-        .antMatchers(HttpMethod.GET, "/api/v1/users/products").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/bidding").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()


### PR DESCRIPTION
- 사용자의 판매 상품 내역 조회에서 인증이 불필요하여 security 설정을 제거하였습니다.