### PR TITLE
[BM-198] 상품 최소 금액 검증 로직 및 테스트 추가, 수정

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
@@ -24,8 +24,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bidding extends BaseTime {
 
-  private static final long UNIT_AMOUNT = 100;
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -33,13 +31,14 @@ public class Bidding extends BaseTime {
   @NotNull
   private long biddingPrice;
 
+  private boolean won;
+
   @ManyToOne(fetch = FetchType.EAGER)
   private User bidder;
 
   @ManyToOne(fetch = FetchType.EAGER)
   private Product product;
 
-  private boolean won;
 
   @Builder
   public Bidding(BiddingPrice biddingPrice, User bidder, Product product) {

--- a/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/entity/Bidding.java
@@ -50,6 +50,21 @@ public class Bidding extends BaseTime {
     this.bidder = bidder;
     this.product = product;
     this.won = false;
+
+    validateProductProgress();
+    validateBiddingPrice();
+  }
+
+  private void validateProductProgress() {
+    if (!product.isProgressed()) {
+      throw new IllegalArgumentException("비딩이 종료된 상품에 비딩할 수 없습니다.");
+    }
+  }
+
+  private void validateBiddingPrice() {
+    if (biddingPrice < product.getMinimumPrice()) {
+      throw new IllegalArgumentException("상품의 최소 금액 이하로는 비딩할 수 없습니다.");
+    }
   }
 
   public void win() {

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -37,16 +37,9 @@ public class DefaultBiddingService implements BiddingService {
 
     User bidder = userRepository.findById(createDto.getBidderId().getValue())
                                 .orElseThrow(NotFoundException::new);
+
     Product product = productRepository.findById(createDto.getProductId().getValue())
                                        .orElseThrow(NotFoundException::new);
-
-    if (!product.isProgressed()) {
-      throw new IllegalArgumentException("비딩이 종료된 상품에 비딩할 수 없습니다.");
-    }
-
-    if (createDto.getBiddingPrice().getValue() < product.getMinimumPrice()) {
-      throw new IllegalArgumentException("상품의 비딩 최소 금액 이하로는 비딩할 수 없습니다. ");
-    }
 
     Bidding bidding = new Bidding(createDto.getBiddingPrice(), bidder, product);
 

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -44,6 +44,10 @@ public class DefaultBiddingService implements BiddingService {
       throw new IllegalArgumentException("비딩이 종료된 상품에 비딩할 수 없습니다.");
     }
 
+    if (createDto.getBiddingPrice().getValue() < product.getMinimumPrice()) {
+      throw new IllegalArgumentException("상품의 비딩 최소 금액 이하로는 비딩할 수 없습니다. ");
+    }
+
     Bidding bidding = new Bidding(createDto.getBiddingPrice(), bidder, product);
 
     Bidding createdBidding = biddingRepository.save(bidding);

--- a/src/test/java/com/saiko/bidmarket/bidding/repository/BiddingRepositoryTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/repository/BiddingRepositoryTest.java
@@ -119,7 +119,7 @@ public class BiddingRepositoryTest {
         Bidding bidding = biddingRepository.save(Bidding.builder()
                                                         .bidder(bidder)
                                                         .product(product)
-                                                        .biddingPrice(BiddingPrice.valueOf(1000))
+                                                        .biddingPrice(BiddingPrice.valueOf(10000))
                                                         .build());
 
         UserBiddingSelectRequest userBiddingSelectRequest = new UserBiddingSelectRequest(0, 1,

--- a/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
@@ -137,6 +137,37 @@ class DefaultBiddingServiceTest {
             .isInstanceOf(IllegalArgumentException.class);
       }
     }
+    
+    @Nested
+    @DisplayName("해당 상품의 최소 금액보다 적게 비딩 금액을 입력하면")
+    class ContextAmountSmallerThanMinPrice {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 발생시킨다.")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        long priceValue = 1000L;
+        BiddingPrice biddingPrice = BiddingPrice.valueOf(priceValue);
+        UnsignedLong productId = UnsignedLong.valueOf(1);
+        UnsignedLong bidderId = UnsignedLong.valueOf(1);
+        BiddingCreateDto createDto = BiddingCreateDto.builder()
+                                                     .biddingPrice(biddingPrice)
+                                                     .bidderId(bidderId)
+                                                     .productId(productId)
+                                                     .build();
+
+        ReflectionTestUtils.setField(product, "progressed", false);
+        ReflectionTestUtils.setField(product, "minimumPrice", (int) priceValue * 2);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(bidder));
+        given(productRepository.findById(anyLong())).willReturn(Optional.of(product));
+
+        // when
+        // then
+        assertThatThrownBy(() -> biddingService.create(createDto))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
 
     @Nested
     @DisplayName("BiddingCreateDto의 bidder Id에 해당하는 사용자가 없으면")

--- a/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
@@ -475,7 +475,7 @@ class DefaultUserServiceTest {
         Bidding bidding = Bidding.builder()
                                  .product(product)
                                  .bidder(bidder)
-                                 .biddingPrice(BiddingPrice.valueOf(10000))
+                                 .biddingPrice(BiddingPrice.valueOf(20000))
                                  .build();
 
         given(biddingRepository.findAllUserBidding(anyLong(), any(UserBiddingSelectRequest.class)))


### PR DESCRIPTION
### 주요 내용
- 상품 최소 금액 검증 로직 및 테스트 추가, 수정

### 상세 내용
- 기획 상 상품의 최소 금액 이상의 금액을 비딩해야 하고 이보다 적은 금액은 비딩되지 않도록 해야 되는데 해당 부분이 누락되어 있었습니다. 
- 이 부분에 대한 로직을 도메인 객체에 추가 및 테스트 구현 하였습니다.
- 추가로 기존 테스트 중에 비딩 금액이 상품 최소 금액보다 작은 케이스가 있어서 수정하였습니다.