### PR TITLE
[BM-199] :recycle: 판매 상품 목록 조회 인증안하고 접근 가능하도록 수정

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -110,7 +110,6 @@ public class WebSecurityConfig {
 
     http.authorizeRequests()
         .antMatchers(HttpMethod.POST, "/api/v1/products").hasAnyRole("USER", "ADMIN")
-        .antMatchers(HttpMethod.GET, "/api/v1/users/products").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/bidding").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()

--- a/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
@@ -60,13 +60,13 @@ public class UserApiController {
     return userService.findById(userId);
   }
 
-  @GetMapping("products")
+  @GetMapping("{encodedId}/products")
   @ResponseStatus(HttpStatus.OK)
   public List<UserProductSelectResponse> getAllUserProduct(
-      @AuthenticationPrincipal JwtAuthentication authentication,
-      @ModelAttribute @Valid UserProductSelectRequest request
+      @ModelAttribute @Valid UserProductSelectRequest request,
+      @PathVariable String encodedId
   ) {
-    long userId = authentication.getUserId();
+    final long userId = IdEncoder.decode(encodedId);
     return userService.findAllUserProducts(userId, request);
   }
 

--- a/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saiko.bidmarket.common.util.IdEncoder;
 import com.saiko.bidmarket.product.Sort;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
@@ -340,7 +341,7 @@ class UserApiControllerTest extends ControllerSetUp {
       }
     }
   }
-  @WithMockCustomLoginUser
+
   @Nested
   @DisplayName("getAllUserProduct 메서드는")
   class DescribeGetAllUserProduct {
@@ -353,6 +354,7 @@ class UserApiControllerTest extends ControllerSetUp {
       @DisplayName("상품을 조회하고 결과를 반환한다")
       void ItReturnProductList() throws Exception {
         //given
+        String encodedId = IdEncoder.encode(1);
         Product product = Product.builder()
                                  .title("감자팜")
                                  .description("가격 선제")
@@ -376,7 +378,7 @@ class UserApiControllerTest extends ControllerSetUp {
 
         //when
         MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
-            .get(BASE_URL + "/products")
+            .get(BASE_URL +  "/" + encodedId + "/products")
             .contentType(MediaType.APPLICATION_FORM_URLENCODED)
             .queryParam("offset", "1")
             .queryParam("limit", "1")


### PR DESCRIPTION
상품 목록 조회 로그인 하지않고 접근 가능하도록 수정했습니다.

Long Id로 하려다가 저희 회원 정보 조회 응답이 String이라 프론트에서 인코딩된 값을 가지고 있기때문에 동일하게 인코딩 아이디로 받습니다. 이부분은 나중에 전체적인 수정 진행하면 될것 같습니다.