### PR TITLE
[BM-245] 경매 종료시 비딩한 사람이 없을 때의 로직 추가

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
@@ -8,5 +8,5 @@ public interface BiddingService {
 
   UnsignedLong create(BiddingCreateDto createDto);
 
-  long selectWinner(Product product);
+  Long selectWinner(Product product);
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -49,17 +49,19 @@ public class DefaultBiddingService implements BiddingService {
   }
 
   @Override
-  public long selectWinner(Product product) {
+  public Long selectWinner(Product product) {
     Assert.notNull(product, "product must be provided");
 
     List<Bidding> biddings = biddingRepository.findAllByProductOrderByBiddingPriceDesc(product);
 
-    //TODO: 비딩한 내역이 존재하지 않는 Product일 경우 로직 구현
+    if (biddings.isEmpty()) {
+      return null;
+    }
 
     biddings.get(0).win();
 
     if (biddings.size() == 1) {
-      return product.getMinimumPrice();
+      return (long)product.getMinimumPrice();
     }
 
     return biddings.get(1).getBiddingPrice() + 1000L;

--- a/src/main/java/com/saiko/bidmarket/product/entity/Product.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Product.java
@@ -61,7 +61,7 @@ public class Product extends BaseTime {
 
   private boolean progressed;
 
-  private long winningPrice;
+  private Long winningPrice;
 
   @NotNull
   private LocalDateTime expireAt;
@@ -117,12 +117,12 @@ public class Product extends BaseTime {
     return imageUrls.get(0);
   }
 
-  public void finish(long winningPrice) {
+  public void finish(Long winningPrice) {
     this.progressed = false;
     setWinningPrice(winningPrice);
   }
 
-  private void setWinningPrice(long winningPrice) {
+  private void setWinningPrice(Long winningPrice) {
     this.winningPrice = winningPrice;
   }
 }

--- a/src/main/resources/sql/product/product_schema.sql
+++ b/src/main/resources/sql/product/product_schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE `product`
     location        varchar(100),
     thumbnail_image varchar(512),
     progressed      tinyint(1)   not null,
-    winning_price   bigint       not null default 0,
+    winning_price   bigint,
     expire_at       timestamp    not null,
     created_at      timestamp,
     updated_at      timestamp,


### PR DESCRIPTION
* Product 엔티티 winningPrice 필드 타입을 long -> Long 타입으로 변경
* 비딩한 사람이 없을 경우 null 삽입