### PR TITLE
[BM-248] :sparkles: 댓글 엔티티 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/comment/entity/Comment.java
+++ b/src/main/java/com/saiko/bidmarket/comment/entity/Comment.java
@@ -1,0 +1,52 @@
+package com.saiko.bidmarket.comment.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.entity.BaseTime;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTime {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @NotNull
+  @Column(length = 500)
+  private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id")
+  private Product product;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User writer;
+
+  @Builder
+  public Comment(String content, Product product, User writer) {
+    Assert.hasText(content, "Content must be provided");
+    Assert.notNull(product, "Product must be provided");
+    Assert.notNull(writer, "Writer must be provided");
+
+    this.content = content;
+    this.product = product;
+    this.writer = writer;
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,12 +10,12 @@ spring:
       schema-locations:
         - classpath:sql/chat/chat_schema.sql
         - classpath:sql/bidding/bidding_schema.sql
+        - classpath:sql/comment/comment_schema.sql
         - classpath:sql/product/product_schema.sql
         - classpath:sql/report/report_schema.sql
         - classpath:sql/user/user_schema.sql
         - classpath:sql/user/oauth2_authorized_client.sql
         - classpath:org/springframework/security/oauth2/client/oauth2-client-schema.sql
-        - classpath:sql/comment/comment_schema.sql
         - classpath:sql/constraint.sql
       data-locations:
         - classpath:sql/user/user_data.sql

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
         - classpath:sql/user/user_schema.sql
         - classpath:sql/user/oauth2_authorized_client.sql
         - classpath:org/springframework/security/oauth2/client/oauth2-client-schema.sql
+        - classpath:sql/comment/comment_schema.sql
         - classpath:sql/constraint.sql
       data-locations:
         - classpath:sql/user/user_data.sql

--- a/src/main/resources/sql/comment/comment_schema.sql
+++ b/src/main/resources/sql/comment/comment_schema.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS `comment` CASCADE;
+
+CREATE TABLE `comment`
+(
+    id         bigint       not null,
+    content    varchar(500) not null,
+    product_id bigint,
+    user_id    bigint
+);

--- a/src/main/resources/sql/comment/comment_schema.sql
+++ b/src/main/resources/sql/comment/comment_schema.sql
@@ -4,6 +4,6 @@ CREATE TABLE `comment`
 (
     id         bigint       not null,
     content    varchar(500) not null,
-    product_id bigint,
-    user_id    bigint
+    product_id bigint       not null,
+    user_id    bigint       not null
 );

--- a/src/main/resources/sql/comment/comment_schema.sql
+++ b/src/main/resources/sql/comment/comment_schema.sql
@@ -5,5 +5,7 @@ CREATE TABLE `comment`
     id         bigint       not null,
     content    varchar(500) not null,
     product_id bigint       not null,
-    user_id    bigint       not null
+    user_id    bigint       not null,
+    created_at timestamp    not null,
+    updated_at timestamp
 );

--- a/src/main/resources/sql/product/product_schema.sql
+++ b/src/main/resources/sql/product/product_schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE `product`
     progressed      tinyint(1)   not null,
     winning_price   bigint,
     expire_at       timestamp    not null,
-    created_at      timestamp,
+    created_at      timestamp    not null,
     updated_at      timestamp,
     user_id         bigint
 );
@@ -24,6 +24,6 @@ CREATE TABLE `image`
     product_id bigint,
     url        varchar(512) not null,
     `order`    int          not null,
-    created_at timestamp,
+    created_at timestamp    not null,
     updated_at timestamp
 );

--- a/src/main/resources/sql/user/user_schema.sql
+++ b/src/main/resources/sql/user/user_schema.sql
@@ -30,6 +30,6 @@ CREATE TABLE `user`
     provider_id   varchar(80) NOT NULL,
     profile_image varchar(512) DEFAULT NULL,
     group_id      bigint      NOT NULL,
-    created_at    timestamp,
+    created_at    timestamp   NOT NULL,
     updated_at    timestamp
 );


### PR DESCRIPTION
## 댓글 길이 제한 의견 주시면 수정하겠습니다!
* 우선 product 엔티티와 동일하게 길이 제한을 500으로 하였습니다.

## 기존 코드 수정 사항
* product, user created_at컬럼에 not null 추가했습니다.