### PR TITLE
[BM-229] 웹소켓 설정 및 채팅 메시지 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.testcontainers:junit-jupiter:1.17.2'
     testImplementation 'org.testcontainers:mysql:1.17.2'
+    testImplementation 'com.h2database:h2'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompileOnly 'org.projectlombok:lombok:1.18.24'

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'com.auth0:java-jwt:3.19.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/saiko/bidmarket/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/ChatWebSocketController.java
@@ -1,0 +1,41 @@
+package com.saiko.bidmarket.chat.controller;
+
+import javax.validation.Valid;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
+import com.saiko.bidmarket.chat.controller.dto.ChatSendMessage;
+import com.saiko.bidmarket.chat.service.ChatMessageService;
+import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@Controller
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+public class ChatWebSocketController {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final ChatMessageService chatService;
+
+  @MessageMapping("/room/{id}")
+  @SendTo("/chat/room/{id}")
+  public ChatPublishMessage send(@DestinationVariable long id,
+                                 @Valid ChatSendMessage chatSendMessage) {
+    log.info("Chat Message | room : {}, user : {}, content : {}", id, chatSendMessage.getUserId(),
+             chatSendMessage.getContent());
+
+    ChatMessageCreateParam param = ChatMessageCreateParam.of(id, chatSendMessage);
+
+    return chatService.create(param);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatPublishMessage.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatPublishMessage.java
@@ -1,0 +1,33 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatPublishMessage {
+
+  private long userId;
+
+  private String content;
+
+  private LocalDateTime createdAt;
+
+  public static ChatPublishMessage of(ChatMessage chatMessage) {
+    return ChatPublishMessage.builder()
+                             .userId(chatMessage.getSender().getId())
+                             .content(chatMessage.getMessage())
+                             .createdAt(chatMessage.getCreatedAt())
+                             .build();
+  }
+}
+

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatSendMessage.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatSendMessage.java
@@ -1,0 +1,21 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import javax.validation.constraints.Positive;
+
+import org.hibernate.validator.constraints.Length;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+public class ChatSendMessage {
+
+  @Positive
+  private final long userId;
+
+  @Length(min = 1, max = 2000)
+  private final String content;
+
+}

--- a/src/main/java/com/saiko/bidmarket/chat/entity/ChatMessage.java
+++ b/src/main/java/com/saiko/bidmarket/chat/entity/ChatMessage.java
@@ -9,11 +9,19 @@ import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotBlank;
 
 import org.hibernate.validator.constraints.Length;
+import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.entity.BaseTime;
 import com.saiko.bidmarket.user.entity.User;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseTime {
 
   @Id
@@ -27,7 +35,17 @@ public class ChatMessage extends BaseTime {
   private ChatRoom chatRoom;
 
   @NotBlank
-  @Length(max = 2000)
+  @Length(min = 1, max = 2000)
   private String message;
 
+  @Builder(access = AccessLevel.PUBLIC)
+  private ChatMessage(User sender, ChatRoom chatRoom, String message) {
+    Assert.notNull(sender, "Sender must be provided");
+    Assert.notNull(chatRoom, "ChatRoom must be provided");
+    Assert.hasText(message, "Message must be provided");
+
+    this.sender = sender;
+    this.chatRoom = chatRoom;
+    this.message = message;
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/entity/ChatRoom.java
+++ b/src/main/java/com/saiko/bidmarket/chat/entity/ChatRoom.java
@@ -3,31 +3,48 @@ package com.saiko.bidmarket.chat.entity;
 import java.util.List;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import org.springframework.util.Assert;
+
 import com.saiko.bidmarket.common.entity.BaseTime;
 import com.saiko.bidmarket.user.entity.User;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private User seller;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private User buyer;
 
   @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ChatMessage> chatMessage;
 
+  @Builder
+  private ChatRoom(User seller, User buyer) {
+    Assert.notNull(seller, "Seller must be provided");
+    Assert.notNull(buyer, "Buyer must be provided");
+
+    this.seller = seller;
+    this.buyer = buyer;
+  }
 }
 

--- a/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
@@ -1,0 +1,8 @@
+package com.saiko.bidmarket.chat.service;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
+import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
+
+public interface ChatMessageService {
+  ChatPublishMessage create(ChatMessageCreateParam createParam);
+}

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
@@ -1,0 +1,15 @@
+package com.saiko.bidmarket.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
+import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
+
+@Service
+public class DefaultChatMessageService implements ChatMessageService {
+
+  @Override
+  public ChatPublishMessage create(ChatMessageCreateParam createParam) {
+    return null;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/chat/service/dto/ChatMessageCreateParam.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/dto/ChatMessageCreateParam.java
@@ -1,0 +1,35 @@
+package com.saiko.bidmarket.chat.service.dto;
+
+import javax.validation.constraints.Positive;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatSendMessage;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageCreateParam {
+
+  @Positive
+  private final long userId;
+
+  @Positive
+  private final long roomId;
+
+  @Length(min = 1, max = 2000)
+  private final String content;
+
+  public static ChatMessageCreateParam of(long roomId, ChatSendMessage sendMessage) {
+    return ChatMessageCreateParam.builder()
+                                 .roomId(roomId)
+                                 .userId(sendMessage.getUserId())
+                                 .content(sendMessage.getContent())
+                                 .build();
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/common/config/WebSocketConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSocketConfig.java
@@ -13,7 +13,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws-stomp")
-            .setAllowedOrigins("*")
+            .setAllowedOrigins("https://bidmarket.vercel.app/")
             .withSockJS();
   }
 

--- a/src/main/java/com/saiko/bidmarket/common/config/WebSocketConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.saiko.bidmarket.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws-stomp")
+            .setAllowedOrigins("*")
+            .withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/chat", "error");
+    registry.setApplicationDestinationPrefixes("/message");
+  }
+}

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatWebSocketControllerTest.java
@@ -1,0 +1,153 @@
+package com.saiko.bidmarket.chat.controller;
+
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.*;
+
+import java.lang.reflect.Type;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
+import com.saiko.bidmarket.chat.controller.dto.ChatSendMessage;
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+import com.saiko.bidmarket.chat.entity.ChatRoom;
+import com.saiko.bidmarket.chat.service.ChatMessageService;
+import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+
+@ActiveProfiles("ws_test")
+@SpringBootTest(webEnvironment = DEFINED_PORT)
+class ChatWebSocketControllerTest {
+
+  @MockBean
+  ChatMessageService chatMessageService;
+
+  BlockingQueue<Object> blockingQueue;
+  WebSocketStompClient stompClient;
+  WebSocketHttpHeaders handshakeHeaders;
+  StompHeaders connectHeaders;
+  StompSession session;
+
+  String WS_URI = "ws://localhost:8080/ws-stomp";
+
+  StompSessionHandlerAdapter getStompSessionHandlerAdapter() {
+    return new StompSessionHandlerAdapter() {
+    };
+  }
+
+  StompFrameHandler getStompFrameHandler(Class<?> type) {
+    return new StompFrameHandler() {
+
+      @Override
+      public @NotNull Type getPayloadType(@NotNull StompHeaders headers) {
+        return type;
+      }
+
+      @Override
+      public void handleFrame(@NotNull StompHeaders headers, Object payload) {
+        blockingQueue.add(payload);
+      }
+    };
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    blockingQueue = new LinkedBlockingDeque<>();
+    stompClient = new WebSocketStompClient(
+        new SockJsClient(List.of(new WebSocketTransport(new StandardWebSocketClient()))));
+
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    handshakeHeaders = new WebSocketHttpHeaders();
+    connectHeaders = new StompHeaders();
+    session = stompClient.connect(WS_URI, handshakeHeaders, connectHeaders,
+                                  getStompSessionHandlerAdapter()).get(1, SECONDS);
+  }
+
+  private User getUser(long userId) {
+    User user = User.builder()
+                    .username("강철중")
+                    .profileImage("https://naver.com/img1")
+                    .provider("naver")
+                    .group(new Group())
+                    .providerId("1234")
+                    .build();
+
+    ReflectionTestUtils.setField(user, "id", userId);
+    return user;
+  }
+
+  private ChatRoom getChatRoom(long roomId) {
+    ChatRoom chatRoom = ChatRoom.builder()
+                                .seller(getUser(1L))
+                                .buyer(getUser(2L))
+                                .build();
+    ReflectionTestUtils.setField(chatRoom, "id", roomId);
+    return chatRoom;
+  }
+
+  @Nested
+  @DisplayName("send 메서드는")
+  class DescribeSend {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("메시지를 발행한다")
+      void ItPublishMessage() throws Exception {
+        //given
+        long userId = 1L;
+        long roomId = 1L;
+
+        String subUrl = MessageFormat.format("/chat/room/{0}", roomId);
+        session.subscribe(subUrl, getStompFrameHandler(ChatPublishMessage.class));
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                                             .message("Test content")
+                                             .sender(getUser(userId))
+                                             .chatRoom(getChatRoom(roomId))
+                                             .build();
+
+        ChatPublishMessage chatPublishMessage = ChatPublishMessage.of(chatMessage);
+        given(chatMessageService.create(any(ChatMessageCreateParam.class)))
+            .willReturn(chatPublishMessage);
+
+        //when
+        String pubUrl = MessageFormat.format("/message/room/{0}", roomId);
+        session.send(pubUrl, new ChatSendMessage(userId, "Test content"));
+
+        //then
+        ChatPublishMessage publishMessage = (ChatPublishMessage)blockingQueue.poll(1, SECONDS);
+        assertNotNull(publishMessage);
+      }
+    }
+  }
+}

--- a/src/test/resources/application-ws_test.yaml
+++ b/src/test/resources/application-ws_test.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+    hikari:
+      jdbc-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MySQL;NON_KEYWORDS=USER
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    generate-ddl: true
+  sql:
+    init:
+      mode: never
+


### PR DESCRIPTION
## 주요사항 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/28651727/183275047-733a63a8-605e-4ae4-8017-738437dee1a6.png">

프론트의 stomp 클라이언트는 ws-stomp 의 엔드포인트로 http 요청을 통해 핸드셰이크를 하고 message/room/{채팅방 번호}, chat/room/{채팅방 번호} 로 각각 메시지 발행, 구독을 하게 됩니다.

### 테스트 관련
- 웹소켓 테스트를 짜는데, WebMvcTest처럼 테스트 하고자 하는 기능(웹소켓)만 따로 빼서 테스트 할 수있는 기능이 없어서 SpringBootTest로 통합테스트를 진행해야 합니다. 통합테스트를 진행하면, Repository관련 의존성이 로드가 되어야되서 TestContainer를 로드할수 밖에 없게되는데 테스트 속도가 너무느립니다. 그래서 웹소켓 테스트만 h2 db로 진행하였습니다.
- 해당 테스트는 통합테스트이긴 하지만, repository 레이어 테스트하는것이 아니기 때문에 큰 문제는 없을것 같습니다.
- 웹소켓용 테스트 프로퍼티를 따로 만들었습니다(ws_test.yaml)

### 에러 핸들러 관련(실패테스트)
- 실패테스트를 위해서는 웹소켓 에러핸들러까지 구현해야하는데 PR이 너무 커지는것 같아 다음 PR에 올리겠습니다. 