### PR TITLE
[BM-258] 웹소켓 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/ChatWebSocketController.java
@@ -5,6 +5,7 @@ import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
@@ -37,5 +38,10 @@ public class ChatWebSocketController {
     ChatMessageCreateParam param = ChatMessageCreateParam.of(id, chatSendMessage);
 
     return chatService.create(param);
+  }
+
+  @MessageExceptionHandler(RuntimeException.class)
+  public void handleException(RuntimeException e) {
+    log.info(e.getMessage());
   }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatSendMessage.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatSendMessage.java
@@ -1,5 +1,6 @@
 package com.saiko.bidmarket.chat.controller.dto;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 
 import org.hibernate.validator.constraints.Length;
@@ -15,6 +16,7 @@ public class ChatSendMessage {
   @Positive
   private final long userId;
 
+  @NotBlank
   @Length(min = 1, max = 2000)
   private final String content;
 


### PR DESCRIPTION
- 채팅 메시지가 유효하지 않은 데이터로 잘못전달된경우 어떤 채널로 에러를 보낼지, 혹은 서버 로그만찍을지 에 대한 논의를 프론트랑 해야할것 같습니다.
- 우선 핸들러구현을 통해 예외발생을 확인하는 정도로만 하고, 논의후에 예외처리를 세분화하겠습니다.