### PR TITLE
[BM-222] 경매 종료 로직 리팩토링

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/entity/Biddings.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/entity/Biddings.java
@@ -1,0 +1,29 @@
+package com.saiko.bidmarket.bidding.entity;
+
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+public class Biddings {
+  private List<Bidding> biddingList;
+
+  public Biddings(List<Bidding> biddingList) {
+    this.biddingList = biddingList;
+  }
+
+  public Long selectWinner(int minimumPrice) {
+    Assert.isTrue(minimumPrice > 0, "MinimumPrice must be positive");
+
+    if (biddingList.isEmpty()) {
+      return null;
+    }
+
+    biddingList.get(0).win();
+
+    if (biddingList.size() == 1) {
+      return (long)minimumPrice;
+    }
+
+    return biddingList.get(1).getBiddingPrice() + 1000L;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/BiddingService.java
@@ -8,5 +8,4 @@ public interface BiddingService {
 
   UnsignedLong create(BiddingCreateDto createDto);
 
-  Long selectWinner(Product product);
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/service/DefaultBiddingService.java
@@ -1,7 +1,5 @@
 package com.saiko.bidmarket.bidding.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -46,24 +44,5 @@ public class DefaultBiddingService implements BiddingService {
     Bidding createdBidding = biddingRepository.save(bidding);
 
     return UnsignedLong.valueOf(createdBidding.getId());
-  }
-
-  @Override
-  public Long selectWinner(Product product) {
-    Assert.notNull(product, "product must be provided");
-
-    List<Bidding> biddings = biddingRepository.findAllByProductOrderByBiddingPriceDesc(product);
-
-    if (biddings.isEmpty()) {
-      return null;
-    }
-
-    biddings.get(0).win();
-
-    if (biddings.size() == 1) {
-      return (long)product.getMinimumPrice();
-    }
-
-    return biddings.get(1).getBiddingPrice() + 1000L;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/entity/Product.java
+++ b/src/main/java/com/saiko/bidmarket/product/entity/Product.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.bidding.entity.Bidding;
 import com.saiko.bidmarket.common.entity.BaseTime;
 import com.saiko.bidmarket.product.Category;
 import com.saiko.bidmarket.user.entity.User;
@@ -73,6 +74,9 @@ public class Product extends BaseTime {
   @JoinColumn(name = "user_id")
   private User writer;
 
+  @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Bidding> biddings = new ArrayList<>();
+
   protected Product() {
   }
 
@@ -118,6 +122,8 @@ public class Product extends BaseTime {
   }
 
   public void finish(Long winningPrice) {
+    Assert.notNull(winningPrice, "winningPrice must be provided");
+
     this.progressed = false;
     setWinningPrice(winningPrice);
   }

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.bidding.entity.Biddings;
 import com.saiko.bidmarket.bidding.service.BiddingService;
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
@@ -92,8 +94,9 @@ public class DefaultProductService implements ProductService {
     }
 
     for (Product product : products) {
-      long winningPrice = biddingService.selectWinner(product);
-      product.finish(winningPrice);
+      Biddings biddings = new Biddings(product.getBiddings());
+      int minimumPrice = product.getMinimumPrice();
+      product.finish(biddings.selectWinner(minimumPrice));
     }
   }
 }

--- a/src/test/java/com/saiko/bidmarket/bidding/entity/BiddingsTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/entity/BiddingsTest.java
@@ -1,0 +1,156 @@
+package com.saiko.bidmarket.bidding.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+
+public class BiddingsTest {
+
+  @Nested
+  @DisplayName("selectWinner 메소드는")
+  class DescribeSelectWinner {
+
+    @Nested
+    @DisplayName("minimumPrice가 음수면")
+    class ContextNegativeMinimumPrice {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 발생시킨다.")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        User writer = writer();
+        Product product = product(writer);
+        User bidder = bidder();
+        BiddingPrice biddingPrice = BiddingPrice.valueOf(10000L);
+        Bidding bidding = bidding(biddingPrice, bidder, product);
+        Biddings biddings = new Biddings(List.of(bidding));
+        int minimumPrice = -1;
+
+        //when, then
+        assertThatCode(() -> biddings.selectWinner(minimumPrice)).isInstanceOf(
+            IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("비딩한 사람이 아무도 없다면")
+    class ContextNotExistBidder {
+
+      @Test
+      @DisplayName("null을 반환한다.")
+      void ItResponseNull() {
+        //given
+        Biddings biddings = new Biddings(Collections.emptyList());
+        int minimumPrice = 10000;
+
+        //when
+        Long winningPrice = biddings.selectWinner(minimumPrice);
+
+        //then
+        assertThat(winningPrice).isNull();
+      }
+    }
+
+    @Nested
+    @DisplayName("비딩한 사람이 한 명이라면")
+    class ContextOneBidder {
+
+      @Test
+      @DisplayName("최소 주문 금액을 반환한다")
+      void ItResponseMinimumPrice() {
+        //given
+        User writer = writer();
+        Product product = product(writer);
+        User bidder = bidder();
+        BiddingPrice biddingPrice = BiddingPrice.valueOf(10000L);
+        Bidding bidding = bidding(biddingPrice, bidder, product);
+        Biddings biddings = new Biddings(List.of(bidding));
+        int minimumPrice = 10000;
+
+        //when
+        Long winningPrice = biddings.selectWinner(minimumPrice);
+
+        //then
+        assertThat(bidding).extracting("won").isEqualTo(true);
+        assertThat(winningPrice).isEqualTo(minimumPrice);
+      }
+    }
+
+    @Nested
+    @DisplayName("비딩한 사람이 여러 명이라면")
+    class ContextManyBidder {
+
+      @Test
+      @DisplayName("2등 입찰가 + 1000원을 반환한다.")
+      void ItResponseMinimumPrice() {
+        //given
+        User writer = writer();
+        Product product = product(writer);
+        User bidderOne = bidder();
+        User bidderTwo = bidder();
+        BiddingPrice biddingPriceOne = BiddingPrice.valueOf(10000L);
+        BiddingPrice biddingPriceTwo = BiddingPrice.valueOf(20000L);
+        Bidding biddingOne = bidding(biddingPriceOne, bidderOne, product);
+        Bidding biddingTwo = bidding(biddingPriceTwo, bidderTwo, product);
+        Biddings biddings = new Biddings(List.of(biddingTwo, biddingOne));
+        int minimumPrice = 10000;
+
+        //when
+        Long winningPrice = biddings.selectWinner(minimumPrice);
+
+        //then
+        assertThat(biddingTwo).extracting("won").isEqualTo(true);
+        assertThat(biddingOne).extracting("won").isEqualTo(false);
+        assertThat(winningPrice).isEqualTo(biddingOne.getBiddingPrice() + 1000L);
+      }
+    }
+  }
+
+  private User writer() {
+    return User.builder()
+               .username("testWriter")
+               .profileImage("imageURL")
+               .provider("provider")
+               .providerId("providerId")
+               .group(new Group())
+               .build();
+  }
+
+    private User bidder() {
+      return User.builder()
+                 .username("testBidder")
+                 .profileImage("imageURL")
+                 .provider("provider")
+                 .providerId("providerId")
+                 .group(new Group())
+                 .build();
+    }
+
+  private Product product(User writer) {
+    return Product.builder()
+                  .title("title")
+                  .description("description")
+                  .minimumPrice(10000)
+                  .writer(writer)
+                  .category(Category.ETC)
+                  .build();
+  }
+
+  private Bidding bidding(BiddingPrice biddingPrice, User bidder, Product product) {
+    return Bidding.builder()
+        .biddingPrice(biddingPrice)
+        .bidder(bidder)
+        .product(product)
+        .build();
+  }
+}

--- a/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/bidding/service/DefaultBiddingServiceTest.java
@@ -1,11 +1,8 @@
 package com.saiko.bidmarket.bidding.service;
 
-import static com.saiko.bidmarket.product.Category.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -274,130 +271,5 @@ class DefaultBiddingServiceTest {
 
     }
 
-  }
-
-  @Nested
-  @DisplayName("selectWinner 메소드는")
-  class DescribeSelectWinner {
-
-    @Nested
-    @DisplayName("product가 null이면")
-    class ContextNullProduct {
-
-      @Test
-      @DisplayName("IllegalArgumentException을 발생시킨다.")
-      void ItThrowsIllegalArgumentException() {
-        //when, then
-        assertThatThrownBy(() -> biddingService.selectWinner(null))
-            .isInstanceOf(IllegalArgumentException.class);
-      }
-    }
-
-    @Nested
-    @DisplayName("입찰자가 1명이라면")
-    class ContextOneBidder {
-
-      @Test
-      @DisplayName("경매의 최소 금액을 반환한다.")
-      void ItThrowsMinimumPriceOfProduct() {
-        // given
-        User bidder = new User("제로", "image", "google", "1234", new Group());
-        Product product = Product.builder()
-                                 .title("세탁기 팔아요")
-                                 .description("좋아요")
-                                 .minimumPrice(1000)
-                                 .category(HOUSEHOLD_APPLIANCE)
-                                 .location("수원")
-                                 .writer(writer)
-                                 .images(null)
-                                 .build();
-        ReflectionTestUtils.setField(product, "id", 1L);
-        ReflectionTestUtils.setField(product, "progressed", true);
-
-        BiddingPrice biddingPrice = BiddingPrice.valueOf(10000L);
-        Bidding bidding = new Bidding(biddingPrice, bidder, product);
-
-        given(biddingRepository.findAllByProductOrderByBiddingPriceDesc(any(Product.class)))
-            .willReturn(List.of(bidding));
-
-        // when
-        Long winningPrice = biddingService.selectWinner(product);
-
-        // then
-        assertThat(bidding).extracting("won").isEqualTo(true);
-        assertThat(winningPrice).isEqualTo(1000L);
-      }
-    }
-
-    @Nested
-    @DisplayName("입찰자가 여러명이라면")
-    class ContextManyBidders {
-
-      @Test
-      @DisplayName("2등의 입찰가 + 1000원을 반환한다.")
-      void ItThrowsMinimumPriceOfProduct() {
-        // given
-        User bidderOne = new User("제로", "image", "google", "1234", new Group());
-        User bidderTwo = new User("재이", "image", "google", "1234", new Group());
-        Product product = Product.builder()
-                                 .title("세탁기 팔아요")
-                                 .description("좋아요")
-                                 .minimumPrice(1000)
-                                 .category(HOUSEHOLD_APPLIANCE)
-                                 .location("수원")
-                                 .writer(writer)
-                                 .images(null)
-                                 .build();
-        ReflectionTestUtils.setField(product, "id", 1L);
-        ReflectionTestUtils.setField(product, "progressed", true);
-
-        BiddingPrice biddingPriceOne = BiddingPrice.valueOf(10000L);
-        BiddingPrice biddingPriceTwo = BiddingPrice.valueOf(50000L);
-        Bidding biddingOne = new Bidding(biddingPriceOne, bidderOne, product);
-        Bidding biddingTwo = new Bidding(biddingPriceTwo, bidderTwo, product);
-
-        given(biddingRepository.findAllByProductOrderByBiddingPriceDesc(any(Product.class)))
-            .willReturn(List.of(biddingTwo, biddingOne));
-
-        // when
-        Long winningPrice = biddingService.selectWinner(product);
-
-        // then
-        assertThat(biddingTwo).extracting("won").isEqualTo(true);
-        assertThat(biddingOne).extracting("won").isEqualTo(false);
-        assertThat(winningPrice).isEqualTo(biddingOne.getBiddingPrice() + 1000L);
-      }
-    }
-
-    @Nested
-    @DisplayName("입찰자가 없다면")
-    class ContextNoBidder {
-
-      @Test
-      @DisplayName("경매의 최소 금액을 반환하지 않는다.")
-      void ItThrowsNull() {
-        // given
-        Product product = Product.builder()
-                                 .title("세탁기 팔아요")
-                                 .description("좋아요")
-                                 .minimumPrice(1000)
-                                 .category(HOUSEHOLD_APPLIANCE)
-                                 .location("수원")
-                                 .writer(writer)
-                                 .images(null)
-                                 .build();
-        ReflectionTestUtils.setField(product, "id", 1L);
-        ReflectionTestUtils.setField(product, "progressed", true);
-
-        given(biddingRepository.findAllByProductOrderByBiddingPriceDesc(any(Product.class)))
-            .willReturn(Collections.emptyList());
-
-        // when
-        Long winningPrice = biddingService.selectWinner(product);
-
-        // then
-        assertThat(winningPrice).isEqualTo(null);
-      }
-    }
   }
 }

--- a/src/test/java/com/saiko/bidmarket/product/entity/ProductTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/entity/ProductTest.java
@@ -1,0 +1,76 @@
+package com.saiko.bidmarket.product.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+
+public class ProductTest {
+  @Nested
+  @DisplayName("finish 메소드는")
+  class DescribeFinish {
+
+    @Nested
+    @DisplayName("winningPrice가 null이면")
+    class ContextNullWinningPrice {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 발생시킨다.")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        User writer = user();
+        Product product = product(writer);
+
+        //when, then
+        assertThatCode(() -> product.finish(null)).isInstanceOf(
+            IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("winningPrice가 유효한 값이면")
+    class ContextValidWinningPrice {
+
+      @Test
+      @DisplayName("경매 종료 여부를 수정하고 낙찰가를 세팅한다.")
+      void ItUpdateProgressedAndSetWinningPrice() {
+        //given
+        User writer = user();
+        Product product = product(writer);
+        Long winningPrice = 20000L;
+
+        //when
+        product.finish(winningPrice);
+
+        //then
+        assertThat(product).extracting("progressed").isEqualTo(false);
+        assertThat(product).extracting("winningPrice").isEqualTo(winningPrice);
+      }
+    }
+  }
+
+  private User user() {
+    return User.builder()
+               .username("test")
+               .profileImage("imageURL")
+               .provider("provider")
+               .providerId("providerId")
+               .group(new Group())
+               .build();
+  }
+
+  private Product product(User writer) {
+    return Product.builder()
+                  .title("title")
+                  .description("description")
+                  .minimumPrice(10000)
+                  .writer(writer)
+                  .category(Category.ETC)
+                  .build();
+  }
+}


### PR DESCRIPTION
* 경매 종료 로직을 BiddingService와 ProductService에 걸쳐서 구현을 했었으나, 객체지향적이지 못한 느낌을 받아서 부족하지만 객체지향적으로 리팩토링을 해보았습니다.
* 수정된 사항
  * Product 필드에 `List<Bidding> biddings` 을 추가함으로써 양방향 관계 설정
  * `List<Bidding> biddings` 를 담은 Biddings 일급컬렉션 생성
    * List<Bidding> biddings 리스트는 비즈니스 로직을 제공할 수 있는 방법은 없지만, 일급컬렉션 객체를 생성함으로써 내부에 낙찰자 선정과 낙찰값 선정에 대한 비즈니스 로직을 담았습니다.