### PR TITLE
[BM-260] 신고하기 기능을 위한 신고 서비스, 레포 구현 및 테스트 작성

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/entity/UnsignedLong.java
+++ b/src/main/java/com/saiko/bidmarket/common/entity/UnsignedLong.java
@@ -2,9 +2,11 @@ package com.saiko.bidmarket.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(of = "value")
 public class UnsignedLong {
   static private final long MIN_VALUE = 1;
 
@@ -13,16 +15,16 @@ public class UnsignedLong {
 
   private UnsignedLong(long value) {
     this.value = value;
+    valid();
   }
 
-  private static void valid(long value) {
-    if (value < MIN_VALUE) {
+  private void valid() {
+    if (this.value < MIN_VALUE) {
       throw new IllegalArgumentException("UnsignedLong의 값은 1보다 작을 수 없습니다.");
     }
   }
 
   public static UnsignedLong valueOf(long value) {
-    valid(value);
     return new UnsignedLong(value);
   }
 }

--- a/src/main/java/com/saiko/bidmarket/report/entity/Report.java
+++ b/src/main/java/com/saiko/bidmarket/report/entity/Report.java
@@ -50,7 +50,7 @@ public class Report extends BaseTime {
   }
 
   private void validateUsers() {
-    if (fromUser == toUser) {
+    if (fromUser.equals(toUser)) {
       throw new IllegalArgumentException("신고자와 피신고자는 같을 수 없습니다");
     }
   }

--- a/src/main/java/com/saiko/bidmarket/report/entity/Report.java
+++ b/src/main/java/com/saiko/bidmarket/report/entity/Report.java
@@ -11,7 +11,6 @@ import javax.persistence.ManyToOne;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.entity.BaseTime;
-import com.saiko.bidmarket.common.entity.UnsignedLong;
 import com.saiko.bidmarket.user.entity.User;
 
 import lombok.AccessLevel;
@@ -46,5 +45,13 @@ public class Report extends BaseTime {
     this.reason = reason;
     this.fromUser = fromUser;
     this.toUser = toUser;
+
+    validateUsers();
+  }
+
+  private void validateUsers() {
+    if (fromUser == toUser) {
+      throw new IllegalArgumentException("신고자와 피신고자는 같을 수 없습니다");
+    }
   }
 }

--- a/src/main/java/com/saiko/bidmarket/report/repository/ReportRepository.java
+++ b/src/main/java/com/saiko/bidmarket/report/repository/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.saiko.bidmarket.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.report.entity.Report;
+import com.saiko.bidmarket.user.entity.User;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, UnsignedLong> {
+  boolean existsByFromUserAndToUser(User fromUser, User toUser);
+}

--- a/src/main/java/com/saiko/bidmarket/report/service/DefaultReportService.java
+++ b/src/main/java/com/saiko/bidmarket/report/service/DefaultReportService.java
@@ -1,0 +1,48 @@
+package com.saiko.bidmarket.report.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.report.entity.Report;
+import com.saiko.bidmarket.report.repository.ReportRepository;
+import com.saiko.bidmarket.report.service.dto.ReportCreateDto;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultReportService implements ReportService {
+
+  private final ReportRepository reportRepository;
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UnsignedLong create(ReportCreateDto createDto) {
+    Assert.notNull(createDto, "Report create dto must be provided");
+
+    User fromUser = userRepository.findById(createDto.getFromUserId().getValue())
+                                  .orElseThrow(NotFoundException::new);
+    User toUser = userRepository.findById(createDto.getToUserId().getValue())
+                                .orElseThrow(NotFoundException::new);
+
+    if (reportRepository.existsByFromUserAndToUser(fromUser, toUser)) {
+      throw new IllegalArgumentException("신고자(id: " + fromUser.getId() + ")는 "
+                                             + "피신고자(id: " + toUser.getId() + ")를 "
+                                             + "이미 신고하였습니다.");
+    }
+
+    Report report = Report.builder()
+                          .reason(createDto.getReason())
+                          .fromUser(fromUser)
+                          .toUser(toUser)
+                          .build();
+
+    return UnsignedLong.valueOf(reportRepository.save(report).getId());
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/report/service/ReportService.java
+++ b/src/main/java/com/saiko/bidmarket/report/service/ReportService.java
@@ -1,0 +1,9 @@
+package com.saiko.bidmarket.report.service;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.report.service.dto.ReportCreateDto;
+
+public interface ReportService {
+
+  UnsignedLong create(ReportCreateDto createDto);
+}

--- a/src/main/java/com/saiko/bidmarket/report/service/dto/ReportCreateDto.java
+++ b/src/main/java/com/saiko/bidmarket/report/service/dto/ReportCreateDto.java
@@ -1,0 +1,32 @@
+package com.saiko.bidmarket.report.service.dto;
+
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReportCreateDto {
+
+  private final String reason;
+
+  private final UnsignedLong fromUserId;
+
+  private final UnsignedLong toUserId;
+
+
+  @Builder
+  private ReportCreateDto(String reason, UnsignedLong fromUserId, UnsignedLong toUserId) {
+    Assert.hasText(reason, "Reason must contain contexts");
+    Assert.notNull(fromUserId, "From user id must be provided");
+    Assert.notNull(toUserId, "To userid  must be provided");
+
+    this.reason = reason;
+    this.fromUserId = fromUserId;
+    this.toUserId = toUserId;
+  }
+}
+
+

--- a/src/main/java/com/saiko/bidmarket/user/entity/User.java
+++ b/src/main/java/com/saiko/bidmarket/user/entity/User.java
@@ -17,9 +17,11 @@ import org.springframework.util.Assert;
 import com.saiko.bidmarket.common.entity.BaseTime;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 
 @Entity
 @Table(name = "`user`")
+@EqualsAndHashCode(of = {"provider", "providerId"}, callSuper = false)
 public class User extends BaseTime {
 
   @Id

--- a/src/main/resources/sql/constraint.sql
+++ b/src/main/resources/sql/constraint.sql
@@ -122,3 +122,5 @@ ALTER TABLE `group_permission`
 ALTER TABLE `user`
     ADD UNIQUE unq_provider_and_id (provider, provider_id);
 
+ALTER TABLE `report`
+    ADD UNIQUE unq_from_user_id_to_user_id (from_user_id, to_user_id);

--- a/src/test/java/com/saiko/bidmarket/report/service/DefaultReportServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/report/service/DefaultReportServiceTest.java
@@ -40,17 +40,21 @@ class DefaultReportServiceTest {
 
   private static final String reason = "reason";
 
-  private static final User fromUser = new User("fromUser",
-                                                "imageUrl",
-                                                "provider",
-                                                "providerId",
-                                                new Group());
+  private static final User fromUser = User.builder()
+                                           .username("fromuUser")
+                                           .profileImage("imageUrl")
+                                           .provider("provider")
+                                           .providerId("providerId")
+                                           .group(new Group())
+                                           .build();
 
-  private static final User toUser = new User("toUser",
-                                              "imageUrl",
-                                              "provider",
-                                              "providerId",
-                                              new Group());
+  private static final User toUser = User.builder()
+                                         .username("toUser")
+                                         .profileImage("imageUrl")
+                                         .provider("provider2")
+                                         .providerId("providerId2")
+                                         .group(new Group())
+                                         .build();
 
   @BeforeAll
   static void setUpUsersId() {
@@ -167,7 +171,15 @@ class DefaultReportServiceTest {
       @DisplayName("IllegalArgumentException을 던진다.")
       void ItThrowsIllegalArgumentException() {
         // given
-        User toUser = fromUser;
+        User toUser = User.builder()
+                          .username(fromUser.getUsername())
+                          .profileImage(fromUser.getProfileImage())
+                          .provider("provider")
+                          .providerId("providerId")
+                          .group(fromUser.getGroup())
+                          .build();
+
+        ReflectionTestUtils.setField(toUser, "id", fromUser.getId());
 
         ReportCreateDto createDto = ReportCreateDto
             .builder()

--- a/src/test/java/com/saiko/bidmarket/report/service/DefaultReportServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/report/service/DefaultReportServiceTest.java
@@ -1,0 +1,230 @@
+package com.saiko.bidmarket.report.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.exception.NotFoundException;
+import com.saiko.bidmarket.report.entity.Report;
+import com.saiko.bidmarket.report.repository.ReportRepository;
+import com.saiko.bidmarket.report.service.dto.ReportCreateDto;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultReportServiceTest {
+
+  @InjectMocks
+  private DefaultReportService reportService;
+
+  @Mock
+  private ReportRepository reportRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  private static final long requestUserId = 1L;
+
+  private static final String reason = "reason";
+
+  private static final User fromUser = new User("fromUser",
+                                                "imageUrl",
+                                                "provider",
+                                                "providerId",
+                                                new Group());
+
+  private static final User toUser = new User("toUser",
+                                              "imageUrl",
+                                              "provider",
+                                              "providerId",
+                                              new Group());
+
+  @BeforeAll
+  static void setUpUsersId() {
+    ReflectionTestUtils.setField(fromUser, "id", requestUserId);
+    ReflectionTestUtils.setField(toUser, "id", requestUserId * 2);
+  }
+
+  @Nested
+  @DisplayName("create 메소드는")
+  class DescribeCreateMethod {
+
+    @Nested
+    @DisplayName("빈 CreateDTo가 들어오면")
+    class ContextNullCreateDto {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 던진다")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        ReportCreateDto createDto = null;
+
+        // when
+        // then
+        assertThatThrownBy(() -> reportService.create(createDto))
+            .isInstanceOf(IllegalArgumentException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("fromUser를 찾을 수 없는 경우")
+    class ContextNotFoundFromUser {
+
+      @Test
+      @DisplayName("NotFoundException을 던진다")
+      void ItReturnCreatedReportId() {
+        // given
+        ReportCreateDto createDto = ReportCreateDto
+            .builder()
+            .reason(reason)
+            .fromUserId(UnsignedLong.valueOf(fromUser.getId()))
+            .toUserId(UnsignedLong.valueOf(toUser.getId()))
+            .build();
+
+        given(userRepository.findById(fromUser.getId())).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> reportService.create(createDto))
+            .isInstanceOf(NotFoundException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("toUser를 찾을 수 없는 경우")
+    class ContextNotFoundToUser {
+
+      @Test
+      @DisplayName("NotFoundException을 던진다")
+      void ItReturnCreatedReportId() {
+        // given
+        ReportCreateDto createDto = ReportCreateDto
+            .builder()
+            .reason(reason)
+            .fromUserId(UnsignedLong.valueOf(fromUser.getId()))
+            .toUserId(UnsignedLong.valueOf(toUser.getId()))
+            .build();
+
+        given(userRepository.findById(fromUser.getId())).willReturn(Optional.of(fromUser));
+        given(userRepository.findById(toUser.getId())).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> reportService.create(createDto))
+            .isInstanceOf(NotFoundException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("fromUser가 이미 toUser를 신고한 경우")
+    class ContextExistSameReport {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 던진다")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        ReportCreateDto createDto = ReportCreateDto
+            .builder()
+            .reason(reason)
+            .fromUserId(UnsignedLong.valueOf(fromUser.getId()))
+            .toUserId(UnsignedLong.valueOf(toUser.getId()))
+            .build();
+
+        given(userRepository.findById(fromUser.getId())).willReturn(Optional.of(fromUser));
+        given(userRepository.findById(toUser.getId())).willReturn(Optional.of(toUser));
+        given(reportRepository.existsByFromUserAndToUser(fromUser, toUser))
+            .willReturn(true);
+
+        // when
+        // then
+        assertThatThrownBy(() -> reportService.create(createDto))
+            .isInstanceOf(IllegalArgumentException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("신고자와 피신고자가 같은 경우")
+    class ContextSameUserWithFromAndTo {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 던진다.")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        User toUser = fromUser;
+
+        ReportCreateDto createDto = ReportCreateDto
+            .builder()
+            .reason(reason)
+            .fromUserId(UnsignedLong.valueOf(fromUser.getId()))
+            .toUserId(UnsignedLong.valueOf(toUser.getId()))
+            .build();
+
+        given(userRepository.findById(fromUser.getId())).willReturn(Optional.of(fromUser));
+        given(userRepository.findById(toUser.getId())).willReturn(Optional.of(toUser));
+        given(reportRepository.existsByFromUserAndToUser(fromUser, toUser))
+            .willReturn(false);
+
+        // when
+        // then
+        assertThatThrownBy(() -> reportService.create(createDto))
+            .isInstanceOf(IllegalArgumentException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("정상적인 Create Dto가 인자로 들어올 경우")
+    class ContextValidCreateDto {
+
+      @Test
+      @DisplayName("생성된 Report의 Id를 반환한다.")
+      void ItReturnCreatedReportId() {
+        // given
+        ReportCreateDto createDto = ReportCreateDto
+            .builder()
+            .reason(reason)
+            .fromUserId(UnsignedLong.valueOf(fromUser.getId()))
+            .toUserId(UnsignedLong.valueOf(toUser.getId()))
+            .build();
+        UnsignedLong expected = UnsignedLong.valueOf(1L);
+
+        Report createdReport = Report.builder()
+                                     .reason(reason)
+                                     .fromUser(fromUser)
+                                     .toUser(toUser)
+                                     .build();
+        ReflectionTestUtils.setField(createdReport, "id", expected.getValue());
+
+        given(userRepository.findById(fromUser.getId())).willReturn(Optional.of(fromUser));
+        given(userRepository.findById(toUser.getId())).willReturn(Optional.of(toUser));
+        given(reportRepository.existsByFromUserAndToUser(fromUser, toUser))
+            .willReturn(false);
+        given(reportRepository.save(any(Report.class))).willReturn(createdReport);
+
+        // when
+        UnsignedLong actual = reportService.create(createDto);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 주요 내용
- 중복 신고 방지 로직 추가
- 신고 레포지토리 구현
- 신고 서비스 구현 및 신고 기능 구현
- 신고 서비스 신고 기능 테스트 작성

### 상세 내용
- 중복 신고 방지를 서비스 레이어에서 우선적으로 확인하고 있으며, db에 제약조건으로 db에서도 방지되도록 하였습니다.
- 중복 신고 확인을 위해 신고자와 피신고자를 이용해 신고 조회를 추가하였습니다.
