### PR TITLE
[BM-255] 신고 컨트롤러 및 신고하기 기능 구현, 테스트 작성

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -127,6 +127,7 @@ public class WebSecurityConfig {
     http.authorizeRequests()
         .antMatchers(HttpMethod.POST, "/api/v1/products").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/bidding").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.POST, "/api/v1/reports").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/comments").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.GET, "/api/v1/comments").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()

--- a/src/main/java/com/saiko/bidmarket/common/entity/BaseCreateResponse.java
+++ b/src/main/java/com/saiko/bidmarket/common/entity/BaseCreateResponse.java
@@ -1,0 +1,13 @@
+package com.saiko.bidmarket.common.entity;
+
+import lombok.Getter;
+
+@Getter
+public class BaseCreateResponse {
+
+  private final UnsignedLong id;
+
+  public BaseCreateResponse(UnsignedLong id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
+++ b/src/main/java/com/saiko/bidmarket/common/exception/ExceptionController.java
@@ -7,6 +7,7 @@ import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -70,6 +71,12 @@ public class ExceptionController {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void handleInvalidDataAccessApiUsageException(InvalidDataAccessApiUsageException e) {
     logger.warn("InvalidDataAccessApiUsageException : ", e);
+  }
+
+  @ExceptionHandler(AuthorizationServiceException.class)
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public void handleAuthorizationServiceException(AuthorizationServiceException e) {
+    logger.warn("AuthorizationServiceException : ", e);
   }
 
   @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/com/saiko/bidmarket/report/controller/ReportApiController.java
+++ b/src/main/java/com/saiko/bidmarket/report/controller/ReportApiController.java
@@ -1,0 +1,46 @@
+package com.saiko.bidmarket.report.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+import com.saiko.bidmarket.report.controller.dto.ReportCreateRequest;
+import com.saiko.bidmarket.report.controller.dto.ReportCreateResponse;
+import com.saiko.bidmarket.report.service.ReportService;
+import com.saiko.bidmarket.report.service.dto.ReportCreateDto;
+
+@RestController
+@RequestMapping("api/v1/reports")
+public class ReportApiController {
+
+  private final ReportService reportService;
+
+  public ReportApiController(ReportService reportService) {
+    this.reportService = reportService;
+  }
+
+  @PostMapping()
+  @ResponseStatus(HttpStatus.CREATED)
+  public ReportCreateResponse create(
+      @AuthenticationPrincipal JwtAuthentication authentication,
+      @RequestBody @Valid ReportCreateRequest createRequest
+  ) {
+    ReportCreateDto createDto = ReportCreateDto.builder()
+                                               .requestUserId(
+                                                   UnsignedLong.valueOf(authentication.getUserId()))
+                                               .reason(createRequest.getReason())
+                                               .fromUserId(createRequest.getFromUserId())
+                                               .toUserId(createRequest.getToUserId())
+                                               .build();
+
+    return new ReportCreateResponse(reportService.create(createDto));
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/report/controller/dto/ReportCreateRequest.java
+++ b/src/main/java/com/saiko/bidmarket/report/controller/dto/ReportCreateRequest.java
@@ -1,0 +1,29 @@
+package com.saiko.bidmarket.report.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+
+import lombok.Getter;
+
+@Getter
+public class ReportCreateRequest {
+
+  @NotBlank
+  private final String reason;
+
+  @NotNull
+  private final UnsignedLong fromUserId;
+
+  @NotNull
+  private final UnsignedLong toUserId;
+
+  @JsonCreator
+  public ReportCreateRequest(String reason, long fromUserId, long toUserId) {
+    this.reason = reason;
+    this.fromUserId = UnsignedLong.valueOf(fromUserId);
+    this.toUserId = UnsignedLong.valueOf(toUserId);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/report/controller/dto/ReportCreateResponse.java
+++ b/src/main/java/com/saiko/bidmarket/report/controller/dto/ReportCreateResponse.java
@@ -1,0 +1,10 @@
+package com.saiko.bidmarket.report.controller.dto;
+
+import com.saiko.bidmarket.common.entity.BaseCreateResponse;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+
+public class ReportCreateResponse extends BaseCreateResponse {
+  public ReportCreateResponse(UnsignedLong id) {
+    super(id);
+  }
+}

--- a/src/test/java/com/saiko/bidmarket/report/controller/ReportApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/report/controller/ReportApiControllerTest.java
@@ -1,0 +1,196 @@
+package com.saiko.bidmarket.report.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.report.service.ReportService;
+import com.saiko.bidmarket.report.service.dto.ReportCreateDto;
+import com.saiko.bidmarket.util.ControllerSetUp;
+import com.saiko.bidmarket.util.WithMockCustomLoginUser;
+
+@WebMvcTest(controllers = ReportApiController.class)
+class ReportApiControllerTest extends ControllerSetUp {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ReportService reportService;
+
+  public static final String BASE_URL = "/api/v1/reports";
+
+  public static final String BASE_REASON = "신고 이유";
+
+  public static final long DEFAULT_AUTH_USER_ID = 1L;
+
+  public static final long BASE_FROM_USER_ID = DEFAULT_AUTH_USER_ID;
+
+  public static final long BASE_TO_USER_ID = 2L;
+
+  @Nested
+  @DisplayName("create 메서드는")
+  @WithMockCustomLoginUser
+  class DescribeCreateMethod {
+
+    @Nested
+    @DisplayName("신고 이유가 비었거나 공백일 경우")
+    class ContextEmptyReason {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @DisplayName("400 Badrequest으로 응답한다.")
+      void ItResponseBadRequest(String reason) throws Exception {
+        // given
+        HashMap<String, Object> requestMap = new HashMap<>();
+        requestMap.put("reason", reason);
+        requestMap.put("fromUserId", BASE_FROM_USER_ID);
+        requestMap.put("toUserId", BASE_TO_USER_ID);
+
+        String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        );
+
+        // then
+        verify(reportService, never()).create(any(ReportCreateDto.class));
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("fromUserId가 음수 혹은 0일 경우")
+    class ContextZeroOrNegativeFromUserId {
+
+      @ParameterizedTest
+      @ValueSource(longs = {Long.MIN_VALUE, -1, 0})
+      @DisplayName("400 Badrequest으로 응답한다.")
+      void ItResponseBadRequest(long fromUserId) throws Exception {
+        // given
+        HashMap<String, Object> requestMap = new HashMap<>();
+        requestMap.put("reason", BASE_REASON);
+        requestMap.put("fromUserId", fromUserId);
+        requestMap.put("toUserId", BASE_TO_USER_ID);
+
+        String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        );
+
+        // then
+        verify(reportService, never()).create(any(ReportCreateDto.class));
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("toUserId가 음수 혹은 0일 경우")
+    class ContextZeroOrNegativeToUserId {
+
+      @ParameterizedTest
+      @ValueSource(longs = {Long.MIN_VALUE, -1, 0})
+      @DisplayName("400 Badrequest으로 응답한다.")
+      void ItResponseBadRequest(long toUserId) throws Exception {
+        // given
+        HashMap<String, Object> requestMap = new HashMap<>();
+        requestMap.put("reason", BASE_REASON);
+        requestMap.put("fromUserId", BASE_FROM_USER_ID);
+        requestMap.put("toUserId", toUserId);
+
+        String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        );
+
+        // then
+        verify(reportService, never()).create(any(ReportCreateDto.class));
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("정상적인 요청이 들어올 경우")
+    class ContextValidRequest {
+
+      @Test
+      @DisplayName("201 Created와 생성된 신고 id를 응답한다.")
+      void ItResponseForbidden() throws Exception {
+        // given
+        HashMap<String, Object> requestMap = new HashMap<>();
+        requestMap.put("reason", BASE_REASON);
+        requestMap.put("fromUserId", BASE_FROM_USER_ID);
+        requestMap.put("toUserId", BASE_TO_USER_ID);
+
+        String requestBody = objectMapper.writeValueAsString(requestMap);
+
+        long createdReportId = 1L;
+
+        given(reportService.create(any(ReportCreateDto.class)))
+            .willReturn(UnsignedLong.valueOf(createdReportId));
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        );
+
+        // then
+        verify(reportService, atLeastOnce()).create(any(ReportCreateDto.class));
+        response
+            .andExpect(status().isCreated())
+            .andDo(
+                document(
+                    "Create report",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestFields(
+                        fieldWithPath("reason").type(JsonFieldType.STRING).description("신고 이유"),
+                        fieldWithPath("fromUserId").type(JsonFieldType.NUMBER).description("신고자 식별자"),
+                        fieldWithPath("toUserId").type(JsonFieldType.NUMBER).description("피신고자 식별자")),
+                    responseFields(
+                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("신고 식별자"))
+                )
+            );
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 주요 내용
- 신고하기 컨트롤러 생성
- 신고 생성 기능 구현
- 기본 생성 아이디 반환 객체 생성 및 상속


### 상세 내용
- 생성 후 id를 반환하는 작업이 반복적으로 이루어져서 생성된 아이디를 반환하는 기본 객체를 상속하여 적용해보았습니다.