### PR TITLE
[BM-246] 로그인 요청 url의 리다이렉트 url로 로그인시 리다이렉트

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -161,6 +161,7 @@ public class WebSecurityConfig {
          */
         .oauth2Login()
         .authorizationEndpoint()
+        .baseUri("/oauth2/authorization")
         .authorizationRequestRepository(authorizationRequestRepository())
         .and()
         .successHandler(handler)

--- a/src/main/java/com/saiko/bidmarket/common/util/CookieUtils.java
+++ b/src/main/java/com/saiko/bidmarket/common/util/CookieUtils.java
@@ -1,6 +1,7 @@
 package com.saiko.bidmarket.common.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -16,11 +17,9 @@ public class CookieUtils {
     Cookie[] cookies = request.getCookies();
 
     if (cookies != null && cookies.length > 0) {
-      for (Cookie cookie : cookies) {
-        if (cookie.getName().equals(name)) {
-          return Optional.of(cookie);
-        }
-      }
+      return Arrays.stream(cookies)
+          .filter(cookie -> cookie.getName().equals(name))
+          .findFirst();
     }
 
     return Optional.empty();

--- a/src/main/java/com/saiko/bidmarket/common/util/CookieUtils.java
+++ b/src/main/java/com/saiko/bidmarket/common/util/CookieUtils.java
@@ -1,0 +1,65 @@
+package com.saiko.bidmarket.common.util;
+
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.SerializationUtils;
+
+public class CookieUtils {
+
+  public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(name)) {
+          return Optional.of(cookie);
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  public static Cookie addCookie(HttpServletResponse response, String name, String value,
+                                 int maxAge) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(maxAge);
+    response.addCookie(cookie);
+    return cookie;
+  }
+
+  public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+                                  String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(name)) {
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+
+  public static String serialize(Object object) {
+    return Base64.getUrlEncoder()
+                 .encodeToString(SerializationUtils.serialize((Serializable)object));
+  }
+
+  public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+    return cls.cast(SerializationUtils.deserialize(
+        Base64.getUrlDecoder().decode(cookie.getValue())
+    ));
+  }
+}


### PR DESCRIPTION
기존에 하드코딩으로 되어있던 리다이렉트 url을 프론트에서 처음 요청시 redirect url로 리다이렉트 하도록 수정했습니다.

localhost:8080/oauth2/authorization/google?redirect_uri=http://localhost:3000/auth
이렇게 로그인 요청시 localhost:3000/auth로 리다이렉트 해줌