### PR TITLE
[BM-268] executeClosingProduct 인자 변경(컬렉션 -> 단일 객체)

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/ScheduledConfig.java
@@ -31,9 +31,8 @@ public class ScheduledConfig {
                                              now.getHour(), now.getMinute());
 
       List<Product> productsInProgress = productService.findAllThatNeedToClose(nowTime);
-      if (productsInProgress.size() != 0) {
-        productService.executeClosingProduct(productsInProgress);
-      }
+
+      productsInProgress.forEach(productService::executeClosingProduct);
     }
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import com.saiko.bidmarket.bidding.entity.Bidding;
 import com.saiko.bidmarket.bidding.entity.Biddings;
 import com.saiko.bidmarket.bidding.service.BiddingService;
 import com.saiko.bidmarket.common.exception.NotFoundException;
@@ -88,15 +87,11 @@ public class DefaultProductService implements ProductService {
   }
 
   @Override
-  public void executeClosingProduct(List<Product> products) {
-    if (products.isEmpty()) {
-      throw new IllegalArgumentException("products must be provided");
-    }
+  public void executeClosingProduct(Product product) {
+    Assert.notNull(product, "Product must be provided");
 
-    for (Product product : products) {
-      Biddings biddings = new Biddings(product.getBiddings());
-      int minimumPrice = product.getMinimumPrice();
-      product.finish(biddings.selectWinner(minimumPrice));
-    }
+    Biddings biddings = new Biddings(product.getBiddings());
+    int minimumPrice = product.getMinimumPrice();
+    product.finish(biddings.selectWinner(minimumPrice));
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -19,5 +19,5 @@ public interface ProductService {
 
   List<Product> findAllThatNeedToClose(LocalDateTime nowTime);
 
-  void executeClosingProduct(List<Product> productsInProgress);
+  void executeClosingProduct(Product product);
 }

--- a/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/service/DefaultProductServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -317,14 +316,14 @@ class DefaultProductServiceTest {
   class DescribeExecuteClosingProduct {
 
     @Nested
-    @DisplayName("products 리스트가 비어있으면")
-    class ContextWithEmptyProducts {
+    @DisplayName("product 가 null 값이 전달되면")
+    class ContextWithEmptyProduct {
 
       @Test
       @DisplayName("IllegalArgumentException 예외를 던진다")
       void ItThrowsIllegalArgumentException() {
         //when, then
-        assertThatThrownBy(() -> productService.executeClosingProduct(Collections.emptyList()))
+        assertThatThrownBy(() -> productService.executeClosingProduct(null))
             .isInstanceOf(IllegalArgumentException.class);
       }
     }
@@ -357,8 +356,8 @@ class DefaultProductServiceTest {
         ReflectionTestUtils.setField(product, "biddings", List.of(bidding));
 
         //when, then
-        assertThatCode(() -> productService.executeClosingProduct(
-            List.of(product))).doesNotThrowAnyException();
+        assertThatCode(() -> productService.executeClosingProduct(product))
+            .doesNotThrowAnyException();
       }
     }
   }


### PR DESCRIPTION
경매종료시 종료 대상 상품들에 대해 채팅방을 생성하는 로직을 작성하려고 경매 종료 로직을 확인하였는데, `executeClosingProduct` 메서드가 인자로 컬렉션을 받아 처리하다 보니, 호출된 메서드 내부에서 컬렉션을 풀어주는 for문이 불필요하게 추가됩니다. 가독성을 높이고자 다음과 같이 리팩토링 제안드립니다. @ecvheo1 

- 스트림을 통해 product 컬렉션을 넘기지 말고 product 단일 객체만 executeClosingProduct에 전달