### PR TITLE
[BM-284] Bidding Repository 비딩 금액 조회 기능 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.bidding.repository.dto.BiddingPriceFindingRepoDto;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 
 public interface BiddingCustomRepository {

--- a/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepository.java
@@ -1,10 +1,13 @@
 package com.saiko.bidmarket.bidding.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.saiko.bidmarket.bidding.entity.Bidding;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 
 public interface BiddingCustomRepository {
   List<Bidding> findAllUserBidding(long userId, UserBiddingSelectRequest request);
+
+  Optional<Bidding> findByBidderIdAndProductId(BiddingPriceFindingRepoDto findingRepoDto);
 }

--- a/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/repository/BiddingCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.saiko.bidmarket.product.entity.QProduct.*;
 import static com.saiko.bidmarket.user.entity.QUser.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
@@ -15,6 +16,7 @@ import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.saiko.bidmarket.bidding.entity.Bidding;
+import com.saiko.bidmarket.bidding.repository.dto.BiddingPriceFindingRepoDto;
 import com.saiko.bidmarket.common.Sort;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 
@@ -41,6 +43,18 @@ public class BiddingCustomRepositoryImpl
         .limit(request.getLimit())
         .orderBy(getOrderSpecifier(request.getSort()))
         .fetch();
+  }
+
+  @Override
+  public Optional<Bidding> findByBidderIdAndProductId(BiddingPriceFindingRepoDto findingRepoDto) {
+    Assert.notNull(findingRepoDto, "findingRepoDto id must be provided");
+
+    return Optional.ofNullable(
+        jpaQueryFactory
+            .selectFrom(bidding)
+            .where(bidding.bidder.id.eq(findingRepoDto.getBidderId().getValue()),
+                   bidding.product.id.eq(findingRepoDto.getProductId().getValue()))
+            .fetchFirst());
   }
 
   private OrderSpecifier getOrderSpecifier(Sort sort) {

--- a/src/main/java/com/saiko/bidmarket/bidding/repository/dto/BiddingPriceFindingRepoDto.java
+++ b/src/main/java/com/saiko/bidmarket/bidding/repository/dto/BiddingPriceFindingRepoDto.java
@@ -1,0 +1,25 @@
+package com.saiko.bidmarket.bidding.repository.dto;
+
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BiddingPriceFindingRepoDto {
+
+  private final UnsignedLong bidderId;
+
+  private final UnsignedLong productId;
+
+  @Builder
+  private BiddingPriceFindingRepoDto(UnsignedLong bidderId, UnsignedLong productId) {
+    Assert.notNull(bidderId, "Bidder id must be provided");
+    Assert.notNull(productId, "Product id must be provided");
+
+    this.bidderId = bidderId;
+    this.productId = productId;
+  }
+}


### PR DESCRIPTION
### 주요 내용
- 비딩 금액 조회 기능 구현


### 상세 내용
- 함수명으로 쿼리를 생성할 경우 도메인 객체 조회 로직이 추가 되어서 Select Query가 2번 더 날라가게 됩니다.
- Select Query 없이 id 값으로 바로 조회하기 위해서 JpaQueryFactory 적용하였습니다.