### PR TITLE
[BM-280] :sparkles: 비딩 결과 조회 controller 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -129,7 +129,7 @@ public class WebSecurityConfig {
         .antMatchers(HttpMethod.POST, "/api/v1/bidding").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/reports").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.POST, "/api/v1/comments").hasAnyRole("USER", "ADMIN")
-        .antMatchers(HttpMethod.GET, "/api/v1/comments").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.GET, "/api/v1/products/{productId}/users/{userId}").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()
         .cors()

--- a/src/main/java/com/saiko/bidmarket/product/Role.java
+++ b/src/main/java/com/saiko/bidmarket/product/Role.java
@@ -1,0 +1,19 @@
+package com.saiko.bidmarket.product;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Role {
+  SELLER("판매자"),
+  BIDDER("입찰자"),
+  ;
+  private final String displayName;
+
+  Role(String displayName) {
+    this.displayName = displayName;
+  }
+
+  @JsonValue
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/ProductApiController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.saiko.bidmarket.common.entity.UnsignedLong;
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+import com.saiko.bidmarket.product.controller.dto.BiddingResultResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
@@ -53,5 +55,13 @@ public class ProductApiController {
   @ResponseStatus(HttpStatus.OK)
   public ProductDetailResponse findById(@PathVariable long id) {
     return productService.findById(id);
+  }
+
+  @GetMapping("{productId}/users/{userId}")
+  @ResponseStatus(HttpStatus.OK)
+  public BiddingResultResponse getBiddingResult(@PathVariable long productId,
+                                                @PathVariable long userId) {
+    return productService.getBiddingResult(UnsignedLong.valueOf(productId),
+                                           UnsignedLong.valueOf(userId));
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/controller/dto/BiddingResultResponse.java
+++ b/src/main/java/com/saiko/bidmarket/product/controller/dto/BiddingResultResponse.java
@@ -1,0 +1,50 @@
+package com.saiko.bidmarket.product.controller.dto;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.product.Role;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class BiddingResultResponse {
+  private final Role role;
+  private final boolean biddingSucceed;
+  private final UnsignedLong chatRoomId;
+
+  public static BiddingResultResponse responseForSuccessfulSeller(UnsignedLong chatRoomId) {
+    return BiddingResultResponse.builder()
+                                .role(Role.SELLER)
+                                .biddingSucceed(true)
+                                .chatRoomId(chatRoomId)
+                                .build();
+  }
+
+  public static BiddingResultResponse responseForFailedSeller() {
+    return BiddingResultResponse.builder()
+                                .role(Role.SELLER)
+                                .biddingSucceed(false)
+                                .chatRoomId(null)
+                                .build();
+  }
+
+  public static BiddingResultResponse responseForSuccessfulBidder(UnsignedLong chatRoomId) {
+    return BiddingResultResponse.builder()
+                                .role(Role.BIDDER)
+                                .biddingSucceed(true)
+                                .chatRoomId(chatRoomId)
+                                .build();
+  }
+
+  public static BiddingResultResponse responseForFailedBidder() {
+    return BiddingResultResponse.builder()
+                                .role(Role.BIDDER)
+                                .biddingSucceed(false)
+                                .chatRoomId(null)
+                                .build();
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/DefaultProductService.java
@@ -11,8 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.common.entity.UnsignedLong;
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.notification.event.NotificationCreateEvent;
+import com.saiko.bidmarket.product.controller.dto.BiddingResultResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
@@ -115,5 +117,10 @@ public class DefaultProductService implements ProductService {
                                                                             END_PRODUCT_FOR_BIDDER)
                                                                         .product(product)));
     }
+  }
+
+  @Override
+  public BiddingResultResponse getBiddingResult(UnsignedLong productId, UnsignedLong userId) {
+    return null;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
+++ b/src/main/java/com/saiko/bidmarket/product/service/ProductService.java
@@ -3,6 +3,8 @@ package com.saiko.bidmarket.product.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.product.controller.dto.BiddingResultResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
@@ -20,4 +22,6 @@ public interface ProductService {
   List<Product> findAllThatNeedToClose(LocalDateTime nowTime);
 
   void executeClosingProduct(Product product);
+
+  BiddingResultResponse getBiddingResult(UnsignedLong productId, UnsignedLong userId);
 }

--- a/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/product/controller/ProductApiControllerTest.java
@@ -38,6 +38,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saiko.bidmarket.common.Sort;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.product.controller.dto.BiddingResultResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateRequest;
 import com.saiko.bidmarket.product.controller.dto.ProductCreateResponse;
 import com.saiko.bidmarket.product.controller.dto.ProductDetailResponse;
@@ -650,11 +652,137 @@ class ProductApiControllerTest extends ControllerSetUp {
         // given
         // when
         ResultActions response = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
-                                                                                 .param("title",  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                                                                                 .param("title",
+                                                                                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                                                                                  .param("offset",
                                                                                         "1")
                                                                                  .param("limit",
                                                                                         "1"));
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("getBiddingResult 메서드는")
+  @WithMockCustomLoginUser
+  class DescribeGetBiddingResult {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+      @Test
+      @DisplayName("비딩 결과를 반환한다")
+      void ItReturnBiddingResult() throws Exception {
+        //given
+        UnsignedLong chatRoomId = UnsignedLong.valueOf(1);
+
+        given(productService.getBiddingResult(any(UnsignedLong.class), any(UnsignedLong.class)))
+            .willReturn(BiddingResultResponse.responseForSuccessfulSeller(chatRoomId));
+
+        long productId = 1;
+        long userId = 1;
+
+
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(BASE_URL + "/{productId}/users/{userId}", productId, userId);
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(productService).getBiddingResult(any(UnsignedLong.class), any(UnsignedLong.class));
+        response.andExpect(status().isOk())
+                .andDo(document("Select bidding result", preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                pathParameters(
+                                    parameterWithName("productId").description("상품 아이디"),
+                                    parameterWithName("userId").description("유저 아이디")
+                                ),
+                                responseFields(
+                                    fieldWithPath("role").type(JsonFieldType.STRING)
+                                                       .description("유저 역할"),
+                                    fieldWithPath("biddingSucceed").type(JsonFieldType.BOOLEAN)
+                                                             .description("비딩 성공 여부"),
+                                    fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
+                                                                      .description("채팅방 아이디")
+                                        .optional()
+                                )));
+      }
+    }
+
+    @Nested
+    @DisplayName("productId 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberProductId {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String productId = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL + "/{productId}/users/{userId}", productId, 1));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("userId 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberUserId {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String userId = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL + "/{productId}/users/{userId}", 1, userId));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("productId 에 음수 또는 0이 들어온다면")
+    class ContextNegativeOrZeroNumberProductId {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"0", "-1"})
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest(String productId) throws Exception {
+        // given
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL + "/{productId}/users/{userId}", productId, 1));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("userId 에 음수 또는 0이 들어온다면")
+    class ContextNegativeOrZeroNumberUserId {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"0", "-1"})
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest(String userId) throws Exception {
+        // given
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL + "/{productId}/users/{userId}", 1, userId));
+
         // then
         response.andExpect(status().isBadRequest());
       }


### PR DESCRIPTION
## 비딩 결과 조회 controller 구현
* 자세한 내용은 아래 노션 페이지 참고 하시면 됩니다.
* https://backend-devcourse.notion.site/FE-ff8a34c58c944ae5b573ac6e29503d2c
* 위 노션 페이지에서 응답 결과만 달라졌습니다.

```java
role : string, // 판매자 or 입찰자 (입찰한 적 없는 유저인 경우는 404)
biddingSucceed : boolean, // 입찰 성공 여부 
chatRoomId: number // 채팅방 아이디
```
* api 문서
https://www.notion.so/backend-devcourse/API-eaca9192734e4a868991939c21e04971?p=e2f4f25f934f4f22bc995c621ebd026c&pm=s