### PR TITLE
[BM-291] :adhesive_bandage: 알림 엔티티 필드 수정

### DIFF
--- a/src/main/java/com/saiko/bidmarket/notification/entity/Notification.java
+++ b/src/main/java/com/saiko/bidmarket/notification/entity/Notification.java
@@ -1,7 +1,8 @@
 package com.saiko.bidmarket.notification.entity;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.entity.BaseTime;
+import com.saiko.bidmarket.notification.NotificationType;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.entity.User;
 
@@ -30,8 +32,8 @@ public class Notification extends BaseTime {
   private Long id;
 
   @NotNull
-  @Column(length = 100)
-  private String content;
+  @Enumerated(EnumType.STRING)
+  private NotificationType type;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id")
@@ -42,12 +44,12 @@ public class Notification extends BaseTime {
   private User user;
 
   @Builder
-  public Notification(String content, Product product, User user) {
-    Assert.hasText(content, "Content must be provided");
+  public Notification(NotificationType type, Product product, User user) {
+    Assert.notNull(type, "Type must be provided");
     Assert.notNull(product, "Product must be provided");
     Assert.notNull(user, "User must be provided");
 
-    this.content = content;
+    this.type = type;
     this.product = product;
     this.user = user;
   }

--- a/src/main/java/com/saiko/bidmarket/notification/event/NotificationCreateHandler.java
+++ b/src/main/java/com/saiko/bidmarket/notification/event/NotificationCreateHandler.java
@@ -17,7 +17,7 @@ public class NotificationCreateHandler {
   @EventListener
   public void create(NotificationCreateEvent event) {
     notificationRepository.save(Notification.builder()
-                                    .content(event.getNotificationType().getMessage())
+                                    .type(event.getNotificationType())
                                     .product(event.getProduct())
                                     .user(event.getUser())
                                     .build());

--- a/src/main/resources/sql/notification/notification_schema.sql
+++ b/src/main/resources/sql/notification/notification_schema.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS `notification` CASCADE;
 CREATE TABLE `notification`
 (
     id         bigint       not null,
-    content    varchar(100) not null,
+    type       varchar(100) not null,
     product_id bigint       not null,
     user_id    bigint       not null,
     created_at timestamp    not null,


### PR DESCRIPTION
* 아래 이미지와 같이 알림 타입과 알림 메세지를 동시에 가지고 있어야하기 때문에, 기존에 정의해두었던 enum 타입을 활용하여 필드를 수정하였습니다.

![image](https://user-images.githubusercontent.com/78195316/183553597-ef08e2f0-6705-4a74-89a1-2284760eebdb.png)
