### PR TITLE
[BM-289] 채팅방 조회 API 컨트롤러 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/chat/controller/ChatRoomApiController.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/ChatRoomApiController.java
@@ -1,0 +1,41 @@
+package com.saiko.bidmarket.chat.controller;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectResponse;
+import com.saiko.bidmarket.chat.service.ChatRoomService;
+import com.saiko.bidmarket.chat.service.dto.ChatRoomSelectParam;
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/chatRooms")
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+public class ChatRoomApiController {
+
+  private final ChatRoomService chatRoomService;
+
+  @GetMapping()
+  @ResponseStatus(HttpStatus.OK)
+  public List<ChatRoomSelectResponse> findAll(
+      @AuthenticationPrincipal JwtAuthentication authentication,
+      @ModelAttribute @Valid ChatRoomSelectRequest request
+  ) {
+    long userId = authentication.getUserId();
+    ChatRoomSelectParam param = ChatRoomSelectParam.of(userId, request);
+    return chatRoomService.findAll(param);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectRequest.java
@@ -1,0 +1,18 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatRoomSelectRequest {
+
+  @PositiveOrZero
+  private final long offset;
+
+  @Positive
+  private final int limit;
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectResponse.java
@@ -1,0 +1,92 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import org.springframework.util.Assert;
+
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+import com.saiko.bidmarket.chat.entity.ChatRoom;
+import com.saiko.bidmarket.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+public class ChatRoomSelectResponse {
+
+  @Positive
+  private final long chatRoomId;
+
+  @NotNull
+  private final ProductInfo productInfo;
+
+  @NotNull
+  private final OpponentUserInfo opponentUserInfo;
+
+  @NotBlank
+  private final String lastMessage;
+
+  @NotNull
+  private final LocalDateTime lastMessageDate;
+
+  @Valid
+  @Getter
+  @Builder(access = PRIVATE)
+  @RequiredArgsConstructor(access = PRIVATE)
+  private static class ProductInfo {
+    @Positive
+    private final long productId;
+    @NotBlank
+    private final String thumbnailImg;
+  }
+
+  @Valid
+  @Getter
+  @Builder(access = PRIVATE)
+  @RequiredArgsConstructor(access = PRIVATE)
+  private static class OpponentUserInfo {
+    @Positive
+    private final long userId;
+    @NotBlank
+    private final String profileImg;
+  }
+
+  public static ChatRoomSelectResponse of(
+      ChatRoom chatRoom,
+      User opponent,
+      ChatMessage lastMessage
+  ) {
+    Assert.notNull(chatRoom, "Chat room must be provided");
+    Assert.notNull(opponent, "Opponent must be provided");
+    Assert.notNull(lastMessage, "Last message must be provided");
+
+    ProductInfo productInfo = ProductInfo.builder()
+                                         .productId(chatRoom.getProduct().getId())
+                                         .thumbnailImg(chatRoom.getProduct().getThumbnailImage())
+                                         .build();
+
+    OpponentUserInfo opponentUserInfo = OpponentUserInfo.builder()
+                                                        .userId(opponent.getId())
+                                                        .profileImg(opponent.getProfileImage())
+                                                        .build();
+
+    return ChatRoomSelectResponse.builder()
+                                 .chatRoomId(chatRoom.getId())
+                                 .productInfo(productInfo)
+                                 .opponentUserInfo(opponentUserInfo)
+                                 .lastMessage(lastMessage.getMessage())
+                                 .lastMessageDate(lastMessage.getCreatedAt())
+                                 .build();
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatRoomSelectResponse.java
@@ -44,8 +44,10 @@ public class ChatRoomSelectResponse {
   @Builder(access = PRIVATE)
   @RequiredArgsConstructor(access = PRIVATE)
   private static class ProductInfo {
+
     @Positive
     private final long productId;
+
     @NotBlank
     private final String thumbnailImg;
   }
@@ -55,8 +57,10 @@ public class ChatRoomSelectResponse {
   @Builder(access = PRIVATE)
   @RequiredArgsConstructor(access = PRIVATE)
   private static class OpponentUserInfo {
-    @Positive
-    private final long userId;
+
+    @NotBlank
+    private final String username;
+
     @NotBlank
     private final String profileImg;
   }
@@ -76,7 +80,7 @@ public class ChatRoomSelectResponse {
                                          .build();
 
     OpponentUserInfo opponentUserInfo = OpponentUserInfo.builder()
-                                                        .userId(opponent.getId())
+                                                        .username(opponent.getUsername())
                                                         .profileImg(opponent.getProfileImage())
                                                         .build();
 

--- a/src/main/java/com/saiko/bidmarket/chat/service/ChatRoomService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/ChatRoomService.java
@@ -1,9 +1,15 @@
 package com.saiko.bidmarket.chat.service;
 
+import java.util.List;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectResponse;
 import com.saiko.bidmarket.chat.service.dto.ChatRoomCreateParam;
+import com.saiko.bidmarket.chat.service.dto.ChatRoomSelectParam;
 
 public interface ChatRoomService {
 
   long create(ChatRoomCreateParam createParam);
+
+  List<ChatRoomSelectResponse> findAll(ChatRoomSelectParam selectParam);
 
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatRoomService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatRoomService.java
@@ -1,11 +1,15 @@
 package com.saiko.bidmarket.chat.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectResponse;
 import com.saiko.bidmarket.chat.entity.ChatRoom;
 import com.saiko.bidmarket.chat.repository.ChatRoomRepository;
 import com.saiko.bidmarket.chat.service.dto.ChatRoomCreateParam;
+import com.saiko.bidmarket.chat.service.dto.ChatRoomSelectParam;
 import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.product.repository.ProductRepository;
@@ -47,5 +51,10 @@ public class DefaultChatRoomService implements ChatRoomService {
                                 .build();
 
     return chatRoomRepository.save(chatRoom).getId();
+  }
+
+  @Override
+  public List<ChatRoomSelectResponse> findAll(ChatRoomSelectParam selectParam) {
+    return null;
   }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/dto/ChatRoomSelectParam.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/dto/ChatRoomSelectParam.java
@@ -1,0 +1,36 @@
+package com.saiko.bidmarket.chat.service.dto;
+
+import static lombok.AccessLevel.*;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectRequest;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+public class ChatRoomSelectParam {
+
+  @Positive
+  private final long userId;
+
+  @PositiveOrZero
+  private final long offset;
+
+  @Positive
+  private final int limit;
+
+  public static ChatRoomSelectParam of(long userId, ChatRoomSelectRequest request) {
+    return ChatRoomSelectParam.builder()
+                              .limit(request.getLimit())
+                              .offset(request.getOffset())
+                              .userId(userId)
+                              .build();
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -132,6 +132,7 @@ public class WebSecurityConfig {
         .antMatchers(HttpMethod.POST, "/api/v1/comments").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.GET, "/api/v1/products/{productId}/users/{userId}").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.GET, "/api/v1/biddings/products/{productId}").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.GET, "/api/v1/chatRooms").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()
         .cors()

--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -172,6 +173,7 @@ public class WebSecurityConfig {
          * 예외처리 핸들러
          */
         .exceptionHandling()
+        .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
         .accessDeniedHandler(accessDeniedHandler())
         .and()
         /**

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
@@ -1,0 +1,207 @@
+package com.saiko.bidmarket.chat.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saiko.bidmarket.chat.controller.dto.ChatRoomSelectResponse;
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+import com.saiko.bidmarket.chat.entity.ChatRoom;
+import com.saiko.bidmarket.chat.service.ChatRoomService;
+import com.saiko.bidmarket.chat.service.dto.ChatRoomSelectParam;
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.util.ControllerSetUp;
+import com.saiko.bidmarket.util.WithMockCustomLoginUser;
+
+@WebMvcTest(controllers = ChatRoomApiController.class)
+class ChatRoomApiControllerTest extends ControllerSetUp {
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  ChatRoomService chatRoomService;
+
+  static final String REQUEST_URI = "/api/v1/chatRooms";
+
+  @Nested
+  @WithMockCustomLoginUser
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("유효한 요청 데이터가 전달되면")
+    class ContextWithTokenAndQueryParamHasSameUserId {
+
+      @Test
+      @DisplayName("해당 유저의 채팅 목록을 응답한다")
+      void ItResponseChatRoomList() throws Exception {
+        //given
+        long sellerId = 1L;
+        long winnerId = 2L;
+        long productId = 1L;
+        long chatRoomId = 1L;
+        long chatMessageId = 1L;
+
+        User seller = getUser(sellerId);
+        User winner = getUser(winnerId);
+        Product product = getProduct(seller, productId);
+        ChatRoom chatRoom = getChatRoom(seller, winner, product, chatRoomId);
+        ChatMessage chatMessage = getChatMessage(winner, chatRoom, chatMessageId);
+
+        given(chatRoomService.findAll(any(ChatRoomSelectParam.class)))
+            .willReturn(List.of(ChatRoomSelectResponse.of(chatRoom, winner, chatMessage)));
+
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(REQUEST_URI)
+            .queryParam("offset", "1")
+            .queryParam("limit", "1");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isOk())
+                .andDo(document("List chat rooms",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestParameters(
+                                    parameterWithName("offset").description("채팅방 조회 시작 번호"),
+                                    parameterWithName("limit").description("채팅방 조회 개수")
+                                ),
+                                responseFields(
+                                    fieldWithPath("[].chatRoomId")
+                                        .type(JsonFieldType.NUMBER).description("채팅방 번호"),
+                                    fieldWithPath("[].productInfo.productId")
+                                        .type(JsonFieldType.NUMBER).description("상품 번호"),
+                                    fieldWithPath("[].productInfo.thumbnailImg")
+                                        .type(JsonFieldType.STRING).description("상품 이미지"),
+                                    fieldWithPath("[].opponentUserInfo.userId")
+                                        .type(JsonFieldType.NUMBER).description("상대방 유저 아이디"),
+                                    fieldWithPath("[].opponentUserInfo.profileImg")
+                                        .type(JsonFieldType.STRING).description("상대방 유저 프로필"),
+                                    fieldWithPath("[].lastMessage")
+                                        .type(JsonFieldType.STRING).description("채팅 메시지"),
+                                    fieldWithPath("[].lastMessageDate")
+                                        .type(JsonFieldType.STRING).description("채팅 보낸 시간")
+                                )));
+      }
+    }
+
+    @Nested
+    @DisplayName("offset 이 음수일 경우")
+    class ContextWithNegativeOffset {
+
+      @ParameterizedTest
+      @ValueSource(longs = {-1, Long.MIN_VALUE})
+      @DisplayName("404를 응답한다")
+      void ItResponse404(long offset) throws Exception {
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(REQUEST_URI)
+            .queryParam("offset", String.valueOf(offset))
+            .queryParam("limit", "1");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("limit 양수가 아닐 경우")
+    class ContextWithNonPositiveLimit {
+
+      @ParameterizedTest
+      @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+      @DisplayName("404를 응답한다")
+      void ItResponse404(int limit) throws Exception {
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(REQUEST_URI)
+            .queryParam("offset", "1")
+            .queryParam("limit", String.valueOf(limit));
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+  }
+
+  private User getUser(long userId) {
+    User user = User.builder()
+                    .username("test")
+                    .profileImage("test")
+                    .group(new Group())
+                    .provider("test")
+                    .providerId("test")
+                    .build();
+    ReflectionTestUtils.setField(user, "id", userId);
+    return user;
+  }
+
+  private ChatRoom getChatRoom(User seller, User winner, Product product, long chatRoomId) {
+    ChatRoom chatRoom = ChatRoom.builder()
+                                .product(product)
+                                .seller(seller)
+                                .winner(winner)
+                                .build();
+
+    ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+    return chatRoom;
+  }
+
+  private Product getProduct(User seller, long productId) {
+    Product product = Product.builder()
+                             .title("test")
+                             .images(List.of("https://test.img"))
+                             .category(Category.ETC)
+                             .minimumPrice(10000)
+                             .writer(seller)
+                             .description("test")
+                             .location("test")
+                             .build();
+    ReflectionTestUtils.setField(product, "id", productId);
+    return product;
+  }
+
+  private ChatMessage getChatMessage(User sender, ChatRoom chatRoom, long chatMessageId) {
+    ChatMessage chatMessage = ChatMessage.builder()
+                                         .message("test")
+                                         .chatRoom(chatRoom)
+                                         .sender(sender)
+                                         .build();
+
+    ReflectionTestUtils.setField(chatMessage, "id", chatMessageId);
+    ReflectionTestUtils.setField(chatMessage, "createdAt", LocalDateTime.now());
+    return chatMessage;
+  }
+}

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
@@ -100,8 +100,8 @@ class ChatRoomApiControllerTest extends ControllerSetUp {
                                         .type(JsonFieldType.NUMBER).description("상품 번호"),
                                     fieldWithPath("[].productInfo.thumbnailImg")
                                         .type(JsonFieldType.STRING).description("상품 이미지"),
-                                    fieldWithPath("[].opponentUserInfo.userId")
-                                        .type(JsonFieldType.NUMBER).description("상대방 유저 아이디"),
+                                    fieldWithPath("[].opponentUserInfo.username")
+                                        .type(JsonFieldType.STRING).description("상대방 유저명"),
                                     fieldWithPath("[].opponentUserInfo.profileImg")
                                         .type(JsonFieldType.STRING).description("상대방 유저 프로필"),
                                     fieldWithPath("[].lastMessage")

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatRoomApiControllerTest.java
@@ -134,6 +134,25 @@ class ChatRoomApiControllerTest extends ControllerSetUp {
     }
 
     @Nested
+    @DisplayName("offset 이 숫자가 아닐 경우")
+    class ContextWithNonNumberOffset {
+
+      @Test
+      @DisplayName("404를 응답한다")
+      void ItResponse404() throws Exception {
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(REQUEST_URI)
+            .queryParam("offset", "test")
+            .queryParam("limit", "1");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
     @DisplayName("limit 양수가 아닐 경우")
     class ContextWithNonPositiveLimit {
 
@@ -154,6 +173,24 @@ class ChatRoomApiControllerTest extends ControllerSetUp {
       }
     }
 
+    @Nested
+    @DisplayName("limit 이 숫자가 아닐 경우")
+    class ContextWithNonNumberLimit {
+
+      @Test
+      @DisplayName("404를 응답한다")
+      void ItResponse404() throws Exception {
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(REQUEST_URI)
+            .queryParam("offset", "1")
+            .queryParam("limit", "test");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isBadRequest());
+      }
+    }
   }
 
   private User getUser(long userId) {


### PR DESCRIPTION
## 주요사항

- 사용자가 현재 활성화 되어있는 채팅방을 조회하는 API를 구현하였습니다.
- 무한스크롤 형식으로 offset, limit을 쿼리 파라미터에 포함하였습니다
- 인가되지 않은경우 302가 아닌 403 에러 응답을 주기 위해 AuthenticationEntryPoint를 추가하였습니다. [참고](https://www.notion.so/backend-devcourse/c0954a42b659425e89be36728b62ace4?v=fba9be0e1028483fbc485c2f50704501&p=693a914e65294b15ba4ca87d43f7e8fc&pm=s)

### 요청

```
GET api/v1/charRooms?offset=&limit=
```

### 응답
```json
response
[ {
  "chatRoomId" : 1, //채팅방 번호
  "productInfo" : { //상품 정보
    "productId" : 1,
    "thumbnailImg" : "https://test.img"
  },
  "opponentUserInfo" : { //상대방 유저 정보
    "username" : "test",
    "profileImg" : "test"
  },
  "lastMessage" : "test", //마지막 메시지 내용
  "lastMessageDate" : "2022-08-09T18:33:17.76155" //마지막 메시지 보낸시간
} ]
```