### PR TITLE
[BM-220] 알림 전체 조회 API Controller 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
@@ -1,0 +1,40 @@
+package com.saiko.bidmarket.notification.controller;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
+import com.saiko.bidmarket.notification.service.NotificationService;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/notifications")
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+public class NotificationApiController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  @ResponseStatus(HttpStatus.OK)
+  public List<NotificationSelectResponse> getAllNotification(
+      @AuthenticationPrincipal JwtAuthentication authentication,
+      @ModelAttribute @Valid NotificationSelectRequest request
+      ) {
+    UnsignedLong userId = UnsignedLong.valueOf(authentication.getUserId());
+    return notificationService.findAllNotifications(userId, request);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/notification/controller/dto/NotificationSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/dto/NotificationSelectRequest.java
@@ -1,0 +1,20 @@
+package com.saiko.bidmarket.notification.controller.dto;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import lombok.Getter;
+
+@Getter
+public class NotificationSelectRequest {
+  @PositiveOrZero
+  private final int offset;
+
+  @Positive
+  private final int limit;
+
+  public NotificationSelectRequest(int offset, int limit) {
+    this.offset = offset;
+    this.limit = limit;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/notification/controller/dto/NotificationSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/dto/NotificationSelectResponse.java
@@ -1,0 +1,49 @@
+package com.saiko.bidmarket.notification.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.saiko.bidmarket.comment.controller.dto.CommentSelectResponse;
+import com.saiko.bidmarket.comment.entity.Comment;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.notification.repository.dto.NotificationRepoDto;
+import com.saiko.bidmarket.product.entity.Product;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationSelectResponse {
+  private final UnsignedLong id;
+
+  private final UnsignedLong productId;
+
+  private final String title;
+
+  private final String thumbnailImage;
+
+  private final String type;
+
+  private final String content;
+
+  private final LocalDateTime createdAt;
+
+  private final LocalDateTime updatedAt;
+
+  public static NotificationSelectResponse from(NotificationRepoDto notificationRepoDto) {
+    return NotificationSelectResponse
+        .builder()
+        .id(UnsignedLong.valueOf(notificationRepoDto.getId()))
+        .productId(UnsignedLong.valueOf(notificationRepoDto.getProductId()))
+        .title(notificationRepoDto.getTitle())
+        .thumbnailImage(notificationRepoDto.getThumbnailImage())
+        .type(notificationRepoDto.getType().getType())
+        .content(notificationRepoDto.getType().getMessage())
+        .createdAt(notificationRepoDto.getCreatedAt())
+        .updatedAt(notificationRepoDto.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/notification/repository/dto/NotificationRepoDto.java
+++ b/src/main/java/com/saiko/bidmarket/notification/repository/dto/NotificationRepoDto.java
@@ -1,0 +1,38 @@
+package com.saiko.bidmarket.notification.repository.dto;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.saiko.bidmarket.notification.NotificationType;
+
+import lombok.Getter;
+
+@Getter
+public class NotificationRepoDto {
+  private long id;
+
+  private long productId;
+
+  private String title;
+
+  private String thumbnailImage;
+
+  private NotificationType type;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  @QueryProjection
+  public NotificationRepoDto(long id, long productId, String title, String thumbnailImage,
+                             NotificationType type, LocalDateTime createdAt,
+                             LocalDateTime updatedAt) {
+    this.id = id;
+    this.productId = productId;
+    this.title = title;
+    this.thumbnailImage = thumbnailImage;
+    this.type = type;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
@@ -1,0 +1,19 @@
+package com.saiko.bidmarket.notification.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
+
+@Service
+public class DefaultNotificationService implements NotificationService {
+
+  @Override
+  public List<NotificationSelectResponse> findAllNotifications(UnsignedLong userId,
+                                                               NotificationSelectRequest request) {
+    return null;
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
@@ -1,0 +1,11 @@
+package com.saiko.bidmarket.notification.service;
+
+import java.util.List;
+
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
+
+public interface NotificationService {
+  List<NotificationSelectResponse> findAllNotifications(UnsignedLong userId, NotificationSelectRequest request);
+}

--- a/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
@@ -1,0 +1,228 @@
+package com.saiko.bidmarket.notification.controller;
+
+import static com.saiko.bidmarket.notification.NotificationType.*;
+import static com.saiko.bidmarket.product.Category.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
+import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
+import com.saiko.bidmarket.notification.entity.Notification;
+import com.saiko.bidmarket.notification.repository.dto.NotificationRepoDto;
+import com.saiko.bidmarket.notification.service.NotificationService;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.util.ControllerSetUp;
+import com.saiko.bidmarket.util.WithMockCustomLoginUser;
+
+@WebMvcTest(controllers = NotificationApiController.class)
+public class NotificationApiControllerTest extends ControllerSetUp {
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private NotificationService notificationService;
+
+  public static final String BASE_URL = "/api/v1/notifications";
+
+  @Nested
+  @DisplayName("getAllNotification 메소드는")
+  @WithMockCustomLoginUser
+  class DescribeGetAllNotification {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("유저의 모든 알림을 조회하고 결과를 반환한다")
+      void ItResponseNotificationList() throws Exception {
+        //given
+        User writer = User.builder()
+                          .username("제로")
+                          .profileImage("image")
+                          .provider("google")
+                          .providerId("123")
+                          .group(new Group())
+                          .build();
+        ReflectionTestUtils.setField(writer, "id", 1L);
+
+        User user = User.builder()
+                          .username("마틴")
+                          .profileImage("image")
+                          .provider("google")
+                          .providerId("123")
+                          .group(new Group())
+                          .build();
+        ReflectionTestUtils.setField(user, "id", 2L);
+
+        Product product = Product.builder()
+                                 .title("귤 팔아요")
+                                 .description("맛있어요")
+                                 .category(FOOD)
+                                 .images(List.of("image1"))
+                                 .location("제주도")
+                                 .minimumPrice(1000)
+                                 .writer(writer)
+                                 .build();
+        ReflectionTestUtils.setField(product, "id", 1L);
+
+        Notification notification = Notification.builder()
+                                                .user(user)
+                                                .type(END_PRODUCT_FOR_BIDDER)
+                                                .product(product)
+                                                .build();
+        ReflectionTestUtils.setField(notification, "createdAt", LocalDateTime.now());
+
+        NotificationRepoDto notificationRepoDto = new NotificationRepoDto(1L, product.getId(),
+                                                                          product.getTitle(),
+                                                                          product.getThumbnailImage(),
+                                                                          notification.getType(),
+                                                                          notification.getCreatedAt(),
+                                                                          notification.getUpdatedAt());
+
+        NotificationSelectResponse notificationSelectResponse = NotificationSelectResponse.from(
+            notificationRepoDto);
+
+        given(notificationService.findAllNotifications(any(UnsignedLong.class), any(NotificationSelectRequest.class)))
+            .willReturn(List.of(notificationSelectResponse));
+
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(BASE_URL)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .queryParam("offset", "0")
+            .queryParam("limit", "1");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response.andExpect(status().isOk())
+                .andDo(document("Select notification", preprocessRequest(
+                    prettyPrint()), preprocessResponse(prettyPrint()), requestParameters(
+                    parameterWithName("offset").description("알림 조회 시작 번호"),
+                    parameterWithName("limit").description("알림 조회 개수")), responseFields(
+                    fieldWithPath("[].id").type(JsonFieldType.NUMBER)
+                                          .description("알림 식별자"),
+                    fieldWithPath("[].productId").type(JsonFieldType.NUMBER)
+                                                 .description("상품 식별자"),
+                    fieldWithPath("[].title").type(JsonFieldType.STRING)
+                                             .description("상품 제목"),
+                    fieldWithPath("[].thumbnailImage").type(JsonFieldType.STRING)
+                                                      .description("상품 썸네일 이미지"),
+                    fieldWithPath("[].type").type(JsonFieldType.STRING)
+                                            .description("알림 타입"),
+                    fieldWithPath("[].content").type(JsonFieldType.STRING)
+                                            .description("알림 메세지"),
+                    fieldWithPath("[].createdAt").type(JsonFieldType.STRING)
+                                                 .description("알림 생성 시간"),
+                    fieldWithPath("[].updatedAt").type(JsonFieldType.STRING)
+                                                 .description("알림 수정 시간").optional())));
+      }
+    }
+
+    @Nested
+    @DisplayName("offset 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberOffset {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String offset = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL).param("offset", offset));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("offset 에 음수가 들어온다면")
+    class ContextNegativeNumberOffset {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL).param("offset", "-1"));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("limit 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberLimit {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String limit = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL)
+                                            .param("offset", "1")
+                                            .param("limit", limit)
+        );
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("limit 에 양수가 아닌 숫자가 들어오면")
+    class ContextNegativeOrZeroNumberLimit {
+
+      @ParameterizedTest
+      @ValueSource(strings = {"0", "-1"})
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest(String limit) throws Exception {
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(BASE_URL)
+                                            .param("offset", "1")
+                                            .param("limit", limit)
+        );
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+  }
+}


### PR DESCRIPTION
* 알림 전체 조회 API Controller 구현입니다.
* ResponseDto 생성을 위하여 넘겨받은 객체는 Repository 계층에서 생성된 DTO 입니다.
  * Product와 Notification 데이터들을 섞어서 받아야하기 때문에 따로 구현하였습니다.
  
## 요청
`Get api/v1/notifications?offset=&limit`

## 응답  
200 OK
```
[
	{
		"id": Number, // 알림 id
		"productId": Number,
		"title": String,
		"thumbnailImage": String,
		"type": String, // ex) 입찰 종료, 상품 댓글
		"content": String, // ex) 아쉽게도 이번에는 낙찰받지 못하셨어요. :( 다음에 다신 도전해주세요.
		"createdAt": Date, // 알림 생성 시간
		"updatedAt": Date
	},
	{} // 유사 데이터 limit 개수만큼 반환
]	
```

