### PR TITLE
[BM-217] 회원탈퇴 api 컨트롤러 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -75,5 +76,14 @@ public class UserApiController {
   ) {
     long userId = authentication.getUserId();
     return userService.findAllUserBiddings(userId, request);
+  }
+
+  @DeleteMapping
+  @ResponseStatus(HttpStatus.OK)
+  public void deleteUser(
+      @AuthenticationPrincipal
+      JwtAuthentication authentication
+  ) {
+    userService.deleteUser(authentication.getUserId());
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -125,4 +125,9 @@ public class DefaultUserService implements UserService {
                             .map(UserBiddingSelectResponse::from)
                             .collect(Collectors.toList());
   }
+
+  @Override
+  public void deleteUser(long userId) {
+
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/user/service/UserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/UserService.java
@@ -26,4 +26,6 @@ public interface UserService {
 
   List<UserBiddingSelectResponse> findAllUserBiddings(long userId,
                                                       UserBiddingSelectRequest request);
+
+  void deleteUser(long userId);
 }

--- a/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
@@ -626,5 +626,28 @@ class UserApiControllerTest extends ControllerSetUp {
       }
     }
   }
-}
 
+  @Nested
+  @DisplayName("deleteUser 메서드는")
+  @WithMockCustomLoginUser
+  class DescribeDeleteUser {
+
+    @Nested
+    @DisplayName("Delete요청을 받으면")
+    class ContextRecieveDeleteRequest {
+
+      @Test
+      @DisplayName("UserService의 deleteUser 메서드를 호출한다.")
+      void itCallServiceDeleteUser() throws Exception {
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.delete(BASE_URL);
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(userService).deleteUser(anyLong());
+        response.andExpect(status().isOk());
+      }
+    }
+  }
+}


### PR DESCRIPTION
요즘 게을러져서 이게 이제야 올라오네요 죄송합니다

회원 탈퇴 api 컨트롤러 구현입니다.

다음 pr에서 서비스 레이어 구현을 올릴텐데 현재 제가 생각한 회원탈퇴 처리는 이렇습니다.

### User Entity

- User Entity의 username을 "Unknown"으로 변경 (이 닉네임은 사용하지 못하게 해야겠죠?)
- provider, providerId 는 null로 변경 -> 현재 NotNull 제약조건이 걸려있는데 해제해야할 것 같습니다.
- 프로필사진은 어떻게 할지 고민중

### Bidding Entity

- 현재 제가 임시로 구현해둔 서비스에서는 해당 유저의 bidding 객체를 모두 삭제하도록 처리했습니다.  (경매에 영향을 주지 않기위해)

### Product Entity

- 해당 유저의 게시물을 모두 finish 처리하도록 구현할 계획입니다.

### Comment Entity 

- 별다른 조치를 취하지 않았습니다. 아마 Unknown의 댓글로 남아있을것 같습니다.

### 고민
---
Product엔티티를 단순히 경매 종료 처리해도 될지 
아마 상품 검색이나 조회시 Unknown의 게시물로 남아있을것 같은데 
soft delete 로 컬럼을 하나 두어 조회하지 않게 처리할지 고민이네요 