### PR TITLE
[BM-321] 신고 객체 재정의

### DIFF
--- a/src/main/java/com/saiko/bidmarket/report/entity/Report.java
+++ b/src/main/java/com/saiko/bidmarket/report/entity/Report.java
@@ -43,13 +43,12 @@ public class Report extends BaseTime {
   @NotNull
   private long typeId;
 
-
-
   @Builder
   private Report(String reason, User fromUser, User toUser, Type type, long typeId) {
     Assert.hasText(reason, "Reason must contain contexts");
     Assert.notNull(fromUser, "From user must be provided");
     Assert.notNull(toUser, "To user must be provided");
+    // TODO: type, typeId Validation 추가 필요(테스트 수정시에 함께 작업)
 
     this.reason = reason;
     this.fromUser = fromUser;

--- a/src/main/java/com/saiko/bidmarket/report/entity/Report.java
+++ b/src/main/java/com/saiko/bidmarket/report/entity/Report.java
@@ -2,6 +2,8 @@ package com.saiko.bidmarket.report.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -38,6 +40,7 @@ public class Report extends BaseTime {
   private User toUser;
 
   @NotNull
+  @Enumerated(value = EnumType.STRING)
   private Type type;
 
   @NotNull

--- a/src/main/java/com/saiko/bidmarket/report/entity/Report.java
+++ b/src/main/java/com/saiko/bidmarket/report/entity/Report.java
@@ -7,6 +7,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
 
 import org.springframework.util.Assert;
 
@@ -36,8 +37,16 @@ public class Report extends BaseTime {
   @ManyToOne(fetch = FetchType.LAZY)
   private User toUser;
 
+  @NotNull
+  private Type type;
+
+  @NotNull
+  private long typeId;
+
+
+
   @Builder
-  private Report(String reason, User fromUser, User toUser) {
+  private Report(String reason, User fromUser, User toUser, Type type, long typeId) {
     Assert.hasText(reason, "Reason must contain contexts");
     Assert.notNull(fromUser, "From user must be provided");
     Assert.notNull(toUser, "To user must be provided");
@@ -45,6 +54,8 @@ public class Report extends BaseTime {
     this.reason = reason;
     this.fromUser = fromUser;
     this.toUser = toUser;
+    this.type = type;
+    this.typeId = typeId;
 
     validateUsers();
   }
@@ -53,5 +64,10 @@ public class Report extends BaseTime {
     if (fromUser.equals(toUser)) {
       throw new IllegalArgumentException("신고자와 피신고자는 같을 수 없습니다");
     }
+  }
+
+  public enum Type {
+    PRODUCT,
+    COMMENT
   }
 }

--- a/src/main/resources/sql/report/report_schema.sql
+++ b/src/main/resources/sql/report/report_schema.sql
@@ -6,6 +6,8 @@ CREATE TABLE `report`
     reason          text         not null,
     from_user_id    bigint       not null,
     to_user_id      bigint       not null,
+    `type`          varchar(16)  not null,
+    type_id         bigint       not null,
     created_at      timestamp    not null,
     updated_at      timestamp
 );


### PR DESCRIPTION
### 주요 내용
- 요구사항 변경에 따른 신고 객체 재정의


### 상세 내용
- AS-IS
  - 신고하기 기능은 사용자가 사용자를 신고
- TO-BE
  - 신고하기 기능은 사용자가 특정 게시물과 그 작성자를 신고
  - 신고하기 기능은 사용자가 특정 댓글과 그 작성자를 신고

- 기존에는 유저를 직접 신고하는 식으로 구현하였으나 게시물이나 댓글을 신고하고 이를 각각 객체와 작성자에 대한 통합 신고 형태로 변환하였습니다.
- 게시물에 대한 신고와 댓글에 대한 신고는 일단 type이라는 필드를 만들어서 구분하고 typeId를 fk 없이 참고키처럼 사용하고자 합니다!

**신고 객체 변화가 발생하면 실제 DB에서 제약 조건에 걸려서 데이터 생성은 되지 않습니다! 테스트 코드는 mocking 되어 있어서 문제 없이 동작합니다. **