### PR TITLE
[BM-321] type, typeId 관련 수정

### DIFF
--- a/src/main/resources/sql/constraint.sql
+++ b/src/main/resources/sql/constraint.sql
@@ -154,3 +154,7 @@ ALTER TABLE `user`
 
 ALTER TABLE `report`
     ADD UNIQUE unq_from_user_id_to_user_id (from_user_id, to_user_id);
+
+-- Index
+ALTER TABLE `report`
+    ADD INDEX idx_type_id_type (type_id, `type`);

--- a/src/main/resources/sql/report/report_schema.sql
+++ b/src/main/resources/sql/report/report_schema.sql
@@ -6,8 +6,8 @@ CREATE TABLE `report`
     reason          text         not null,
     from_user_id    bigint       not null,
     to_user_id      bigint       not null,
-    `type`          varchar(16)  not null,
-    type_id         bigint       not null,
+    `type`          varchar(16),
+    type_id         bigint,
     created_at      timestamp    not null,
     updated_at      timestamp
 );


### PR DESCRIPTION
### 주요 내용
- type, type_id nullable로 변경
- type_id, type  index 추가


### 상세 내용
- type,type_id null인 경우는 비딩 종료 이후 채팅 과정에서 사용자를 직접 신고
  - 이 경우에는 게시물이나 댓글이 아닌 사용자를 직접 신고하여 null이 될 수 있어서 not null을 삭제
- type_id, type index 추가하여 게시물이나 댓글에 대한 신고 조회 시 빠르게 조회
  - type은 type_id에 비해 카디널리티가 낮아서 카디널리티가 높은 type_id부터 index 적용