### PR TITLE
[BM-290] 채팅 메시지 조회 api 컨트롤러 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/chat/controller/ChatMessageApiController.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/ChatMessageApiController.java
@@ -3,10 +3,9 @@ package com.saiko.bidmarket.chat.controller;
 import java.util.List;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Positive;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
 import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
 import com.saiko.bidmarket.chat.service.ChatMessageService;
+import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,11 +30,14 @@ public class ChatMessageApiController {
   @GetMapping("{chatRoomId}/messages")
   @ResponseStatus(HttpStatus.OK)
   public List<ChatMessageSelectResponse> getAll(
+      @AuthenticationPrincipal
+      JwtAuthentication jwtAuthentication,
       @PathVariable
       long chatRoomId,
       @ModelAttribute @Valid
       ChatMessageSelectRequest chatMessageSelectRequest
   ) {
-    return chatMessageService.findAll(chatRoomId, chatMessageSelectRequest);
+    long userId = jwtAuthentication.getUserId();
+    return chatMessageService.findAll(userId, chatRoomId, chatMessageSelectRequest);
   }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/controller/ChatMessageApiController.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/ChatMessageApiController.java
@@ -1,0 +1,40 @@
+package com.saiko.bidmarket.chat.controller;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
+import com.saiko.bidmarket.chat.service.ChatMessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/chatRooms")
+public class ChatMessageApiController {
+
+  private final ChatMessageService chatMessageService;
+
+  @GetMapping("{chatRoomId}/messages")
+  @ResponseStatus(HttpStatus.OK)
+  public List<ChatMessageSelectResponse> getAll(
+      @PathVariable
+      long chatRoomId,
+      @ModelAttribute @Valid
+      ChatMessageSelectRequest chatMessageSelectRequest
+  ) {
+    return chatMessageService.findAll(chatRoomId, chatMessageSelectRequest);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectRequest.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectRequest.java
@@ -1,0 +1,19 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatMessageSelectRequest {
+
+  @PositiveOrZero
+  private final long offset;
+
+  @Positive
+  private final int limit;
+
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
@@ -7,7 +7,6 @@ import com.saiko.bidmarket.chat.entity.ChatMessage;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -17,7 +16,7 @@ public class ChatMessageSelectResponse {
   private final String content;
   private final LocalDateTime createdAt;
 
-  public static ChatMessageSelectResponse of(ChatMessage chatMessage) {
+  public static ChatMessageSelectResponse from(ChatMessage chatMessage) {
     return ChatMessageSelectResponse
         .builder()
         .userId(chatMessage.getSender().getId())

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
@@ -1,0 +1,29 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ChatMessageSelectResponse {
+
+  private final long userId;
+  private final String content;
+  private final LocalDateTime createdAt;
+
+  public static ChatMessageSelectResponse of(ChatMessage chatMessage) {
+    return ChatMessageSelectResponse
+        .builder()
+        .userId(chatMessage.getSender().getId())
+        .content(chatMessage.getMessage())
+        .createdAt(chatMessage.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
@@ -10,5 +10,9 @@ import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
 public interface ChatMessageService {
   ChatPublishMessage create(ChatMessageCreateParam createParam);
 
-  List<ChatMessageSelectResponse> findAll(long chatRoomId, ChatMessageSelectRequest request);
+  List<ChatMessageSelectResponse> findAll(
+      long userId,
+      long chatRoomId,
+      ChatMessageSelectRequest request
+  );
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/ChatMessageService.java
@@ -1,8 +1,14 @@
 package com.saiko.bidmarket.chat.service;
 
+import java.util.List;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
 import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
 import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
 
 public interface ChatMessageService {
   ChatPublishMessage create(ChatMessageCreateParam createParam);
+
+  List<ChatMessageSelectResponse> findAll(long chatRoomId, ChatMessageSelectRequest request);
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
@@ -1,8 +1,13 @@
 package com.saiko.bidmarket.chat.service;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
 import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
 import com.saiko.bidmarket.chat.entity.ChatMessage;
 import com.saiko.bidmarket.chat.entity.ChatRoom;
@@ -44,5 +49,10 @@ public class DefaultChatMessageService implements ChatMessageService {
     ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
     return ChatPublishMessage.of(savedChatMessage);
+  }
+
+  @Override
+  public List<ChatMessageSelectResponse> findAll(long chatRoomId, ChatMessageSelectRequest request) {
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
@@ -54,7 +54,8 @@ public class DefaultChatMessageService implements ChatMessageService {
   @Override
   public List<ChatMessageSelectResponse> findAll(
       long userId,
-      long chatRoomId, ChatMessageSelectRequest request
+      long chatRoomId,
+      ChatMessageSelectRequest request
   ) {
     return Collections.emptyList();
   }

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
@@ -52,7 +52,10 @@ public class DefaultChatMessageService implements ChatMessageService {
   }
 
   @Override
-  public List<ChatMessageSelectResponse> findAll(long chatRoomId, ChatMessageSelectRequest request) {
+  public List<ChatMessageSelectResponse> findAll(
+      long userId,
+      long chatRoomId, ChatMessageSelectRequest request
+  ) {
     return Collections.emptyList();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/saiko/bidmarket/common/config/WebSecurityConfig.java
@@ -133,6 +133,7 @@ public class WebSecurityConfig {
         .antMatchers(HttpMethod.GET, "/api/v1/products/{productId}/result").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.GET, "/api/v1/biddings/products/{productId}").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.GET, "/api/v1/chatRooms").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.GET, "/api/v1/chatRooms/**").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll()
         .and()
         .cors()

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
@@ -34,6 +34,7 @@ import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.entity.Group;
 import com.saiko.bidmarket.user.entity.User;
 import com.saiko.bidmarket.util.ControllerSetUp;
+import com.saiko.bidmarket.util.WithMockCustomLoginUser;
 
 @WebMvcTest(controllers = ChatMessageApiController.class)
 class ChatMessageApiControllerTest extends ControllerSetUp {
@@ -45,6 +46,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
   @DisplayName("getAll 메서드는")
   class DescribeGetAll {
 
+    @WithMockCustomLoginUser
     @Nested
     @DisplayName("유효한 값이 전달되면")
     class ContextWithCall {
@@ -104,6 +106,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
       }
     }
 
+    @WithMockCustomLoginUser
     @Nested
     @DisplayName("메시지 조회 시작번호 가 숫자가 아닌경우")
     class ContextWithNonNumberOffset {
@@ -126,6 +129,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
       }
     }
 
+    @WithMockCustomLoginUser
     @Nested
     @DisplayName("메시지 조회 시작번호가 음수인 경우")
     class ContextWithNegativeNumberOffset {
@@ -152,6 +156,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
     @DisplayName("메시지 조회 개수 가 숫자가 아닌경우")
     class ContextWithNonNumberLimit {
 
+      @WithMockCustomLoginUser
       @Test
       @DisplayName("BadRequest 를 응답한다")
       void ItResponseBadRequest() throws Exception {
@@ -169,6 +174,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
       }
     }
 
+    @WithMockCustomLoginUser
     @Nested
     @DisplayName("메시지 조회 개수가 양수가 아닌 경우")
     class ContextWithNonPositiveNumberLimit {
@@ -188,6 +194,27 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
 
         //then
         perform.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("유저가 권한이 없는 경우")
+    class ContextWithNonAuthorizedMember {
+
+      @Test
+      @DisplayName("forbidden 을 응답한다")
+      void ItResponseForbidden() throws Exception {
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, 1)
+            .queryParam("offset", "0")
+            .queryParam("limit", "10");
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform.andExpect(status().isForbidden());
       }
     }
   }

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
@@ -71,7 +71,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
 
         ChatMessageSelectResponse response = ChatMessageSelectResponse.of(chatMessage);
 
-        given(chatMessageService.findAll(anyLong(), any(ChatMessageSelectRequest.class)))
+        given(chatMessageService.findAll(anyLong(), anyLong(), any(ChatMessageSelectRequest.class)))
             .willReturn(List.of(response));
 
         //when

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
@@ -69,7 +69,7 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
             .queryParam("offset", "0")
             .queryParam("limit", "10");
 
-        ChatMessageSelectResponse response = ChatMessageSelectResponse.of(chatMessage);
+        ChatMessageSelectResponse response = ChatMessageSelectResponse.from(chatMessage);
 
         given(chatMessageService.findAll(anyLong(), anyLong(), any(ChatMessageSelectRequest.class)))
             .willReturn(List.of(response));

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
@@ -1,0 +1,259 @@
+package com.saiko.bidmarket.chat.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
+import com.saiko.bidmarket.chat.entity.ChatMessage;
+import com.saiko.bidmarket.chat.entity.ChatRoom;
+import com.saiko.bidmarket.chat.service.ChatMessageService;
+import com.saiko.bidmarket.product.Category;
+import com.saiko.bidmarket.product.entity.Product;
+import com.saiko.bidmarket.user.entity.Group;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.util.ControllerSetUp;
+
+@WebMvcTest(controllers = ChatMessageApiController.class)
+class ChatMessageApiControllerTest extends ControllerSetUp {
+
+  @MockBean
+  ChatMessageService chatMessageService;
+
+  @Nested
+  @DisplayName("getAll 메서드는")
+  class DescribeGetAll {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithCall {
+
+      @Test
+      @DisplayName("해당 채팅방의 페이징된 메시지 리스트를 반환한다")
+      void ItResponsePageListOfChatMessage() throws Exception {
+        //given
+        long chatRoomId = 1L;
+
+        User seller = getUser(1);
+        User winner = getUser(2);
+        Product product = getProduct(seller, 1);
+        ChatRoom chatRoom = getChatRoom(seller, winner, product, chatRoomId);
+        ChatMessage chatMessage = getChatMessage(seller, chatRoom, 1);
+
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, chatRoomId)
+            .queryParam("offset", "0")
+            .queryParam("limit", "10");
+
+        ChatMessageSelectResponse response = ChatMessageSelectResponse.of(chatMessage);
+
+        given(chatMessageService.findAll(anyLong(), any(ChatMessageSelectRequest.class)))
+            .willReturn(List.of(response));
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform
+            .andExpect(status().isOk())
+            .andDo(document(
+                "Chat Message Select",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("chatRoomId").description("채팅방 번호")
+                ),
+                requestParameters(
+                    parameterWithName("offset").description("메시지 조회 시작 번호"),
+                    parameterWithName("limit").description("메시지 조회 개수")
+                ),
+                responseFields(
+                    fieldWithPath("[].userId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("유저 번호"),
+                    fieldWithPath("[].content")
+                        .type(JsonFieldType.STRING)
+                        .description("채팅 내용"),
+                    fieldWithPath("[].createdAt")
+                        .type(JsonFieldType.STRING)
+                        .description("채팅 보낸 시간")
+                )
+            ));
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지 조회 시작번호 가 숫자가 아닌경우")
+    class ContextWithNonNumberOffset {
+
+      @Test
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest() throws Exception {
+        //given
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, 1)
+            .queryParam("offset", "Test")
+            .queryParam("limit", "10");
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지 조회 시작번호가 음수인 경우")
+    class ContextWithNegativeNumberOffset {
+
+      @ParameterizedTest
+      @ValueSource(longs = {-1, Long.MIN_VALUE})
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest(long offset) throws Exception {
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, 1)
+            .queryParam("offset", String.valueOf(offset))
+            .queryParam("limit", "10");
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지 조회 개수 가 숫자가 아닌경우")
+    class ContextWithNonNumberLimit {
+
+      @Test
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest() throws Exception {
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, 1)
+            .queryParam("offset", "0")
+            .queryParam("limit", "Test");
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform.andExpect(status().isBadRequest());
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지 조회 개수가 양수가 아닌 경우")
+    class ContextWithNonPositiveNumberLimit {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1, Long.MIN_VALUE})
+      @DisplayName("BadRequest 를 응답한다")
+      void ItResponseBadRequest(long limit) throws Exception {
+        String requestUri = "/api/v1/chatRooms/{chatRoomId}/messages";
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(requestUri, 1)
+            .queryParam("offset", "0")
+            .queryParam("limit", String.valueOf(limit));
+
+        //when
+        ResultActions perform = mockMvc.perform(request);
+
+        //then
+        perform.andExpect(status().isBadRequest());
+      }
+    }
+  }
+
+  private User getUser(long userId) {
+    User user = User
+        .builder()
+        .username("test")
+        .profileImage("test")
+        .group(new Group())
+        .provider("test")
+        .providerId("test")
+        .build();
+    ReflectionTestUtils.setField(user, "id", userId);
+    return user;
+  }
+
+  private ChatRoom getChatRoom(
+      User seller,
+      User winner,
+      Product product,
+      long chatRoomId
+  ) {
+    ChatRoom chatRoom = ChatRoom
+        .builder()
+        .product(product)
+        .seller(seller)
+        .winner(winner)
+        .build();
+
+    ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+    return chatRoom;
+  }
+
+  private Product getProduct(
+      User seller,
+      long productId
+  ) {
+    Product product = Product
+        .builder()
+        .title("test")
+        .images(List.of("https://test.img"))
+        .category(Category.ETC)
+        .minimumPrice(10000)
+        .writer(seller)
+        .description("test")
+        .location("test")
+        .build();
+    ReflectionTestUtils.setField(product, "id", productId);
+    return product;
+  }
+
+  private ChatMessage getChatMessage(
+      User sender,
+      ChatRoom chatRoom,
+      long chatMessageId
+  ) {
+    ChatMessage chatMessage = ChatMessage
+        .builder()
+        .message("test")
+        .chatRoom(chatRoom)
+        .sender(sender)
+        .build();
+
+    ReflectionTestUtils.setField(chatMessage, "id", chatMessageId);
+    ReflectionTestUtils.setField(chatMessage, "createdAt", LocalDateTime.now());
+    return chatMessage;
+  }
+}


### PR DESCRIPTION
## 주요사항

채팅방에 접속하면 해당 채팅방의 채팅내역을 DB에서 불러오기 위한 api를 구현하였습니다.

### 요청

```
header : 인증 토큰

$ http GET 'http://localhost:8080/api/v1/chatRooms/{채팅방 번호}/messages?offset={오프셋 시작}&limit={조회개수}
```

### 응답
```json
[ {
  "userId" : 1,
  "content" : "test",
  "createdAt" : "2022-08-12T15:35:08.693689"
} ]
```
