### PR TITLE
[BM-327] 알림 확인 기능 구현

### DIFF
--- a/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
@@ -42,12 +42,12 @@ public class NotificationApiController {
     return notificationService.findAllNotifications(userId, request);
   }
 
-  @PutMapping("{notificationId}")
+  @PutMapping("{id}")
   @ResponseStatus(HttpStatus.OK)
   public void checkNotification(
       @AuthenticationPrincipal JwtAuthentication authentication,
-      @PathVariable long notificationId
+      @PathVariable long id
   ) {
-    notificationService.checkNotification(authentication.getUserId(), notificationId);
+    notificationService.checkNotification(authentication.getUserId(), id);
   }
 }

--- a/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +38,14 @@ public class NotificationApiController {
       ) {
     UnsignedLong userId = UnsignedLong.valueOf(authentication.getUserId());
     return notificationService.findAllNotifications(userId, request);
+  }
+
+  @PutMapping("{notificationId}")
+  @ResponseStatus(HttpStatus.OK)
+  public void checkNotification(
+      @AuthenticationPrincipal JwtAuthentication authentication,
+      @PathVariable long notificationId
+  ) {
+    notificationService.checkNotification(authentication.getUserId(), notificationId);
   }
 }

--- a/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
+++ b/src/main/java/com/saiko/bidmarket/notification/controller/NotificationApiController.java
@@ -33,8 +33,10 @@ public class NotificationApiController {
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   public List<NotificationSelectResponse> getAllNotification(
-      @AuthenticationPrincipal JwtAuthentication authentication,
-      @ModelAttribute @Valid NotificationSelectRequest request
+      @AuthenticationPrincipal
+      JwtAuthentication authentication,
+      @ModelAttribute @Valid
+      NotificationSelectRequest request
       ) {
     UnsignedLong userId = UnsignedLong.valueOf(authentication.getUserId());
     return notificationService.findAllNotifications(userId, request);

--- a/src/main/java/com/saiko/bidmarket/notification/entity/Notification.java
+++ b/src/main/java/com/saiko/bidmarket/notification/entity/Notification.java
@@ -55,4 +55,12 @@ public class Notification extends BaseTime {
     this.product = product;
     this.user = user;
   }
+
+  public boolean isNotPossibleToAccessNotification(long userId) {
+    return !this.user.isSameUser(userId);
+  }
+
+  public void check() {
+    checked = true;
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
@@ -3,22 +3,30 @@ package com.saiko.bidmarket.notification.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
 import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
+import com.saiko.bidmarket.notification.entity.Notification;
 import com.saiko.bidmarket.notification.repository.NotificationRepository;
+import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+@Transactional
 public class DefaultNotificationService implements NotificationService {
 
   private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
 
   @Override
   public List<NotificationSelectResponse> findAllNotifications(UnsignedLong userId,
@@ -30,5 +38,24 @@ public class DefaultNotificationService implements NotificationService {
                             .stream()
                             .map((NotificationSelectResponse::from))
                             .collect(Collectors.toList());
+  }
+
+  @Override
+  public void checkNotification(
+      long userId,
+      long notificationId
+  ) {
+    Assert.isTrue(userId > 0, "UserId must be positive");
+    Assert.isTrue(notificationId > 0, "NotificationId must be positive");
+
+    Notification notification = notificationRepository
+        .findById(notificationId)
+        .orElseThrow(() -> new NotFoundException("Notification not exist"));
+
+    if (notification.isNotPossibleToAccessNotification(userId)) {
+      throw new AuthorizationServiceException("다른 유저의 알림을 확인할 수 없습니다.");
+    }
+
+    notification.check();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/DefaultNotificationService.java
@@ -43,13 +43,13 @@ public class DefaultNotificationService implements NotificationService {
   @Override
   public void checkNotification(
       long userId,
-      long notificationId
+      long id
   ) {
     Assert.isTrue(userId > 0, "UserId must be positive");
-    Assert.isTrue(notificationId > 0, "NotificationId must be positive");
+    Assert.isTrue(id > 0, "NotificationId must be positive");
 
     Notification notification = notificationRepository
-        .findById(notificationId)
+        .findById(id)
         .orElseThrow(() -> new NotFoundException("Notification not exist"));
 
     if (notification.isNotPossibleToAccessNotification(userId)) {

--- a/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
@@ -8,4 +8,9 @@ import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRespons
 
 public interface NotificationService {
   List<NotificationSelectResponse> findAllNotifications(UnsignedLong userId, NotificationSelectRequest request);
+
+  void checkNotification(
+      long userId,
+      long notificationId
+  );
 }

--- a/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
+++ b/src/main/java/com/saiko/bidmarket/notification/service/NotificationService.java
@@ -11,6 +11,6 @@ public interface NotificationService {
 
   void checkNotification(
       long userId,
-      long notificationId
+      long id
   );
 }

--- a/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
@@ -228,4 +228,57 @@ public class NotificationApiControllerTest extends ControllerSetUp {
       }
     }
   }
+
+  @Nested
+  @DisplayName("checkNotification 메소드는")
+  @WithMockCustomLoginUser
+  class DescribeCheckNotification {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("유저의 알림 조회 상태를 변경한다")
+      void ItCheckNotification() throws Exception {
+        //given
+        long notificationId = 1L;
+
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .put(BASE_URL + "/{notificationId}", notificationId)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        response
+            .andExpect(status().isOk())
+            .andDo(document("Check notification", preprocessRequest(
+                                prettyPrint()), preprocessResponse(prettyPrint()), pathParameters(
+                                parameterWithName("notificationId").description("알림 아이디")
+                            )
+            ));
+      }
+    }
+
+    @Nested
+    @DisplayName("notificationId 에 숫자 외에 다른 문자가 들어온다면")
+    class ContextNotNumberNotificationId {
+
+      @Test
+      @DisplayName("BadRequest 로 응답한다.")
+      void itResponseBadRequest() throws Exception {
+        // given
+        String notificationId = "NotNumber";
+
+        // when
+        ResultActions response = mockMvc.perform(
+            RestDocumentationRequestBuilders.put(BASE_URL + "/{notificationId}", notificationId));
+
+        // then
+        response.andExpect(status().isBadRequest());
+      }
+    }
+  }
 }

--- a/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/notification/controller/NotificationApiControllerTest.java
@@ -246,7 +246,7 @@ public class NotificationApiControllerTest extends ControllerSetUp {
 
         //when
         MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
-            .put(BASE_URL + "/{notificationId}", notificationId)
+            .put(BASE_URL + "/{id}", notificationId)
             .contentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         ResultActions response = mockMvc.perform(request);
@@ -256,7 +256,7 @@ public class NotificationApiControllerTest extends ControllerSetUp {
             .andExpect(status().isOk())
             .andDo(document("Check notification", preprocessRequest(
                                 prettyPrint()), preprocessResponse(prettyPrint()), pathParameters(
-                                parameterWithName("notificationId").description("알림 아이디")
+                                parameterWithName("id").description("알림 아이디")
                             )
             ));
       }
@@ -274,7 +274,7 @@ public class NotificationApiControllerTest extends ControllerSetUp {
 
         // when
         ResultActions response = mockMvc.perform(
-            RestDocumentationRequestBuilders.put(BASE_URL + "/{notificationId}", notificationId));
+            RestDocumentationRequestBuilders.put(BASE_URL + "/{id}", notificationId));
 
         // then
         response.andExpect(status().isBadRequest());

--- a/src/test/java/com/saiko/bidmarket/notification/service/DefaultNotificationServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/notification/service/DefaultNotificationServiceTest.java
@@ -6,17 +6,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.saiko.bidmarket.common.entity.UnsignedLong;
+import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.notification.controller.dto.NotificationSelectRequest;
 import com.saiko.bidmarket.notification.controller.dto.NotificationSelectResponse;
 import com.saiko.bidmarket.notification.entity.Notification;
@@ -26,6 +31,7 @@ import com.saiko.bidmarket.product.Category;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.entity.Group;
 import com.saiko.bidmarket.user.entity.User;
+import com.saiko.bidmarket.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 public class DefaultNotificationServiceTest {
@@ -78,32 +84,13 @@ public class DefaultNotificationServiceTest {
       @DisplayName("UserBiddingSelectResponse 를 반환한다")
       void ItResponseNotificationSelectResponseList() {
         //given
-        User user = User.builder()
-                        .username("제로")
-                        .profileImage("image")
-                        .provider("google")
-                        .providerId("123")
-                        .group(new Group())
-                        .build();
+        User user = user("제로");
         ReflectionTestUtils.setField(user, "id", 1L);
 
-        Product product = Product.builder()
-                                 .title("노트북 팝니다1")
-                                 .description("싸요")
-                                 .category(Category.DIGITAL_DEVICE)
-                                 .minimumPrice(10000)
-                                 .images(List.of("thumbnailImage"))
-                                 .location(null)
-                                 .writer(user)
-                                 .build();
+        Product product = product(user, 1000);
         ReflectionTestUtils.setField(product, "id", 1L);
 
-        Notification notification = Notification.builder()
-                                                .user(user)
-                                                .product(product)
-                                                .type(
-                                                    END_PRODUCT_FOR_WRITER_WITH_WINNER)
-                                                .build();
+        Notification notification = notification(user, product);
         ReflectionTestUtils.setField(notification, "id", 1L);
 
         NotificationRepoDto notificationRepoDto = new NotificationRepoDto(notification.getId(),
@@ -145,5 +132,154 @@ public class DefaultNotificationServiceTest {
             notificationSelectResponse.isChecked());
       }
     }
+  }
+
+  @Nested
+  @DisplayName("checkNotification 메서드는")
+  class DescribeCheckNotification {
+
+    @Nested
+    @DisplayName("userId가 양수가 아니면")
+    class ContextWithUserIdNegative {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1, Long.MIN_VALUE})
+      @DisplayName("IllegalArgumentException 예외를 던진다")
+      void ItThrowsIllegalArgumentException(long userId) {
+        //when, then
+        assertThatThrownBy(() -> notificationService.checkNotification(userId, 1L))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("notificationId가 양수가 아니면")
+    class ContextWithNotificationIdNegative {
+
+      @ParameterizedTest
+      @ValueSource(longs = {0, -1, Long.MIN_VALUE})
+      @DisplayName("IllegalArgumentException 예외를 던진다")
+      void ItThrowsIllegalArgumentException(long notificationId) {
+        //when, then
+        assertThatThrownBy(() -> notificationService.checkNotification(1L, notificationId))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("notificationId에 해당하는 알림이 없다면")
+    class ContextNotFoundProductById {
+
+      @Test
+      @DisplayName("NotFoundException을 발생시킨다.")
+      void ItThrowsNotFoundException() {
+        // given
+        long userId = Long.MAX_VALUE;
+        long notificationId = Long.MAX_VALUE;
+
+        given(notificationRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> notificationService.checkNotification(userId, notificationId))
+            .isInstanceOf(NotFoundException.class);
+        verify(notificationRepository, atLeastOnce()).findById(anyLong());
+      }
+    }
+
+    @Nested
+    @DisplayName("확인하려는 userId와 알림의 userId가 일치하지 않으면")
+    class ContextNotMatchNotificationByUserId {
+
+      @Test
+      @DisplayName("AuthorizationServiceException을 발생시킨다.")
+      void ItThrowsAuthorizationServiceException을() {
+        // given
+        long userId = 1L;
+        long notificationId = 1L;
+
+        User user = user("제로");
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Product product = product(user, 1000);
+        ReflectionTestUtils.setField(product, "id", 1L);
+
+        Notification notification = notification(user, product);
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+
+        given(notificationRepository.findById(anyLong())).willReturn(Optional.of(notification));
+
+        // when
+        // then
+        assertThatThrownBy(() -> notificationService.checkNotification(2L, notificationId))
+            .isInstanceOf(AuthorizationServiceException.class);
+        verify(notificationRepository, atLeastOnce()).findById(anyLong());
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidParameters {
+
+      @Test
+      @DisplayName("유저의 알림 조회 상태를 변경한다.")
+      void ItCheckNotification() {
+        // given
+        long userId = 1L;
+        long notificationId = 1L;
+
+        User user = user("제로");
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Product product = product(user, 1000);
+        ReflectionTestUtils.setField(product, "id", 1L);
+
+        Notification notification = notification(user, product);
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+
+        given(notificationRepository.findById(anyLong())).willReturn(Optional.of(notification));
+
+        // when
+        notificationService.checkNotification(userId, notificationId);
+
+        // then
+        verify(notificationRepository).findById(anyLong());
+        assertThat(notification.isChecked()).isTrue();
+      }
+    }
+  }
+
+  private User user(String name) {
+    return User
+        .builder()
+        .username(name)
+        .profileImage("imageURL")
+        .provider("provider")
+        .providerId("providerId")
+        .group(new Group())
+        .build();
+  }
+
+  private Product product(
+      User writer,
+      int minimumPrice
+  ) {
+    return Product
+        .builder()
+        .title("title")
+        .description("description")
+        .minimumPrice(minimumPrice)
+        .writer(writer)
+        .category(Category.ETC)
+        .build();
+  }
+
+  private Notification notification(User user, Product product) {
+    return Notification
+        .builder()
+        .user(user)
+        .product(product)
+        .type(
+            END_PRODUCT_FOR_WRITER_WITH_WINNER)
+        .build();
   }
 }


### PR DESCRIPTION
* 아래 이미지와 같이 알림을 확인하지 않은 것과 이미 확인한 알림을 구별하기 위해, 알림을 확인할 때 요청되는 API를 구현하였습니다.
<img width="337" alt="image" src="https://user-images.githubusercontent.com/78195316/184316605-72d73449-4e87-4235-8fcd-d731650b73a2.png">

### 쿼리
```
Hibernate: 
    select
        notificati0_.id as id1_8_0_,
        notificati0_.created_at as created_2_8_0_,
        notificati0_.updated_at as updated_3_8_0_,
        notificati0_.checked as checked4_8_0_,
        notificati0_.product_id as product_6_8_0_,
        notificati0_.type as type5_8_0_,
        notificati0_.user_id as user_id7_8_0_ 
    from
        notification notificati0_ 
    where
        notificati0_.id=?
Hibernate: 
    select
        user0_.id as id1_12_0_,
        user0_.created_at as created_2_12_0_,
        user0_.updated_at as updated_3_12_0_,
        user0_.group_id as group_id8_12_0_,
        user0_.profile_image as profile_4_12_0_,
        user0_.provider as provider5_12_0_,
        user0_.provider_id as provider6_12_0_,
        user0_.username as username7_12_0_,
        group1_.id as id1_4_1_,
        group1_.name as name2_4_1_ 
    from
        `user` user0_ 
    inner join
        `
    group` group1_ 
        on user0_.group_id=group1_.id where
            user0_.id=?
Hibernate: 
    update
        notification 
    set
        created_at=?,
        updated_at=?,
        checked=?,
        product_id=?,
        type=?,
        user_id=? 
    where
        id=?
```
