### PR TITLE
[BM-294] 채팅방 메시지 조회 Service, Repository 메서드 작성

### DIFF
--- a/src/main/java/com/saiko/bidmarket/chat/entity/ChatRoom.java
+++ b/src/main/java/com/saiko/bidmarket/chat/entity/ChatRoom.java
@@ -65,4 +65,9 @@ public class ChatRoom extends BaseTime {
     return seller.getId() == userId ? winner : seller;
   }
 
+  public void checkParticipant(long userId) {
+    if (seller.getId() != userId && winner.getId() != userId) {
+      throw new IllegalArgumentException("채팅방에 참여중인 사용자가 아닙니다");
+    }
+  }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepository.java
+++ b/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepository.java
@@ -1,11 +1,18 @@
 package com.saiko.bidmarket.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
 import com.saiko.bidmarket.chat.entity.ChatMessage;
 
 public interface ChatMessageCustomRepository {
 
   Optional<ChatMessage> findLastChatMessageOfChatRoom(long chatRoom);
+
+  List<ChatMessage> findAllChatMessage(
+      long chatRoomId,
+      ChatMessageSelectRequest request
+  );
 
 }

--- a/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepositoryImpl.java
@@ -2,13 +2,14 @@ package com.saiko.bidmarket.chat.repository;
 
 import static com.saiko.bidmarket.chat.entity.QChatMessage.*;
 import static com.saiko.bidmarket.chat.entity.QChatRoom.*;
-import static com.saiko.bidmarket.user.entity.QUser.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
 import com.saiko.bidmarket.chat.entity.ChatMessage;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,20 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
             .orderBy(chatMessage.createdAt.desc())
             .fetchFirst()
     );
+  }
+
+  @Override
+  public List<ChatMessage> findAllChatMessage(
+      long chatRoomId,
+      ChatMessageSelectRequest request
+  ) {
+    return jpaQueryFactory
+        .selectFrom(chatMessage)
+        .join(chatMessage.chatRoom, chatRoom)
+        .where(chatMessage.chatRoom.id.eq(chatRoomId))
+        .orderBy(chatMessage.createdAt.desc())
+        .offset(request.getOffset())
+        .limit(request.getLimit())
+        .fetch();
   }
 }

--- a/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
+++ b/src/main/java/com/saiko/bidmarket/chat/service/DefaultChatMessageService.java
@@ -1,9 +1,10 @@
 package com.saiko.bidmarket.chat.service;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
@@ -52,11 +53,22 @@ public class DefaultChatMessageService implements ChatMessageService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public List<ChatMessageSelectResponse> findAll(
       long userId,
       long chatRoomId,
       ChatMessageSelectRequest request
   ) {
-    return Collections.emptyList();
+    Assert.notNull(request, "Request must be provided");
+    chatRoomRepository
+        .findById(chatRoomId)
+        .orElseThrow(() -> new NotFoundException("ChatRoom not exists"))
+        .checkParticipant(userId);
+
+    return chatMessageRepository
+        .findAllChatMessage(chatRoomId, request)
+        .stream()
+        .map(ChatMessageSelectResponse::from)
+        .collect(Collectors.toUnmodifiableList());
   }
 }

--- a/src/test/java/com/saiko/bidmarket/chat/service/DefaultChatMessageServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/service/DefaultChatMessageServiceTest.java
@@ -3,7 +3,9 @@ package com.saiko.bidmarket.chat.service;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
+import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
 import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
 import com.saiko.bidmarket.chat.controller.dto.ChatSendMessage;
 import com.saiko.bidmarket.chat.entity.ChatMessage;
@@ -22,6 +26,7 @@ import com.saiko.bidmarket.chat.entity.ChatRoom;
 import com.saiko.bidmarket.chat.repository.ChatMessageRepository;
 import com.saiko.bidmarket.chat.repository.ChatRoomRepository;
 import com.saiko.bidmarket.chat.service.dto.ChatMessageCreateParam;
+import com.saiko.bidmarket.common.exception.NotFoundException;
 import com.saiko.bidmarket.product.Category;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.entity.Group;
@@ -42,44 +47,6 @@ class DefaultChatMessageServiceTest {
 
   @InjectMocks
   DefaultChatMessageService defaultChatMessageService;
-
-  private User getTestUser(long userId) {
-    User user = User.builder()
-                    .username("test")
-                    .profileImage("test")
-                    .provider("test")
-                    .providerId("test")
-                    .group(new Group())
-                    .build();
-
-    ReflectionTestUtils.setField(user, "id", userId);
-    return user;
-  }
-
-  private ChatRoom getTestChatRoom(long roomId, long user1, long user2, long productId) {
-    ChatRoom chatRoom = ChatRoom.builder()
-                                .winner(getTestUser(user1))
-                                .seller(getTestUser(user2))
-                                .product(getTestProduct(productId, user2))
-                                .build();
-
-    ReflectionTestUtils.setField(chatRoom, "id", roomId);
-    return chatRoom;
-  }
-
-  private Product getTestProduct(long productId, long userId) {
-    Product product = Product.builder()
-                             .title("test")
-                             .images(Collections.emptyList())
-                             .writer(getTestUser(userId))
-                             .description("test")
-                             .minimumPrice(1000)
-                             .category(Category.BEAUTY)
-                             .build();
-
-    ReflectionTestUtils.setField(product, "id", productId);
-    return product;
-  }
 
   @Nested
   @DisplayName("create 메서드는")
@@ -107,20 +74,21 @@ class DefaultChatMessageServiceTest {
       @DisplayName("생성된 메시지에 대한 정보를 담은 DTO를 반환한다")
       void ItReturnDTO() {
         //given
-        long roomId = 1L;
-        long senderUserId = 1L;
-        long receiverUserId = 2L;
-        long productId = 1L;
+        User seller = getUser(1L);
+        User winner = getUser(2L);
+        Product product = getProduct(1L, seller.getId());
+        ChatRoom chatRoom = getChatRoom(1L, seller, winner, product);
+
         String content = "Test content";
 
-        ChatSendMessage chatSendMessage = new ChatSendMessage(senderUserId, content);
-        ChatMessageCreateParam createParam = ChatMessageCreateParam.of(roomId, chatSendMessage);
+        ChatSendMessage chatSendMessage = new ChatSendMessage(seller.getId(), content);
+        ChatMessageCreateParam createParam = ChatMessageCreateParam.of(chatRoom.getId(), chatSendMessage);
 
         given(chatRoomRepository.findById(anyLong()))
-            .willReturn(Optional.of(getTestChatRoom(roomId, senderUserId, receiverUserId, productId)));
+            .willReturn(Optional.of(chatRoom));
 
         given(userRepository.findById(anyLong()))
-            .willReturn(Optional.of(getTestUser(senderUserId)));
+            .willReturn(Optional.of(seller));
 
         given(chatMessageRepository.save(any(ChatMessage.class)))
             .willAnswer(methodInvocationMock -> methodInvocationMock.getArguments()[0]);
@@ -134,5 +102,166 @@ class DefaultChatMessageServiceTest {
       }
     }
 
+  }
+
+  @Nested
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("request 값이 null이면")
+    class ContextWithNullRequest {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 던진다")
+      void ItThrowsIllegalArgumentException() {
+        //when, that
+        assertThatThrownBy(() -> defaultChatMessageService.findAll(1, 1, null))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("해당 채팅방이 존재하지 않으면")
+    class ContextWithChatRoomNotExists {
+
+      @Test
+      @DisplayName("NotFoundException 에러를 던진다")
+      void ItThrowNotFoundException() {
+        //given
+        ChatMessageSelectRequest request = new ChatMessageSelectRequest(0, 10);
+        given(chatRoomRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> defaultChatMessageService.findAll(1L, 1L, request))
+            .isInstanceOf(NotFoundException.class);
+
+      }
+    }
+
+    @Nested
+    @DisplayName("user 가 해당 채팅방에 속해있지 않으면")
+    class ContextWithUserIsNotParticipant {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 던진다")
+      void ItThrowsIllegalArgumentException() {
+        //given
+        User seller = getUser(1);
+        User winner = getUser(2);
+        Product product = getProduct(1, 1);
+        ChatRoom chatRoom = getChatRoom(1, seller, winner, product);
+        ChatMessageSelectRequest request = new ChatMessageSelectRequest(0, 10);
+
+        given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+
+        //when, then
+        assertThatThrownBy(() -> defaultChatMessageService.findAll(3L, 1L, request))
+            .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValid {
+
+      @Test
+      @DisplayName("해당 채팅방의 채팅 메시지 리스트를 반환한다")
+      void ItReturnChatMessages() {
+        //given
+        int messageNum = 10;
+        User seller = getUser(1);
+        User winner = getUser(2);
+        Product product = getProduct(1, 1);
+        ChatRoom chatRoom = getChatRoom(1, seller, winner, product);
+        ChatMessageSelectRequest request = new ChatMessageSelectRequest(0, 10);
+
+        given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(chatRoom));
+        given(chatMessageRepository.findAllChatMessage(
+            anyLong(),
+            any(ChatMessageSelectRequest.class)
+        )).willReturn(getChatMessages(chatRoom, seller, messageNum));
+
+        //when
+        List<ChatMessageSelectResponse> responses =
+            defaultChatMessageService.findAll(seller.getId(), 1L, request);
+
+        //then
+        assertThat(responses.size()).isEqualTo(messageNum);
+      }
+    }
+
+  }
+
+  private List<ChatMessage> getChatMessages(
+      ChatRoom chatRoom,
+      User sender,
+      int count
+  ) {
+    List<ChatMessage> chatMessages = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      chatMessages.add(getChatMessage(chatRoom, sender));
+    }
+    return chatMessages;
+  }
+
+  private ChatMessage getChatMessage(
+      ChatRoom chatRoom,
+      User sender
+  ) {
+    return ChatMessage
+        .builder()
+        .chatRoom(chatRoom)
+        .sender(sender)
+        .message("test")
+        .build();
+  }
+
+  private ChatRoom getChatRoom(
+      long chatRoomId,
+      User seller,
+      User winner,
+      Product product
+  ) {
+    ChatRoom chatRoom = ChatRoom
+        .builder()
+        .seller(seller)
+        .winner(winner)
+        .product(product)
+        .build();
+    ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+    return chatRoom;
+  }
+
+  private User getUser(long userId) {
+    User user = User
+        .builder()
+        .username("test")
+        .provider("test")
+        .providerId("test")
+        .profileImage("test")
+        .group(new Group())
+        .build();
+
+    ReflectionTestUtils.setField(user, "id", userId);
+    return user;
+  }
+
+  private Product getProduct(
+      long productId,
+      long userId
+  ) {
+    Product product = Product
+        .builder()
+        .title("test")
+        .images(Collections.emptyList())
+        .writer(getUser(userId))
+        .description("test")
+        .minimumPrice(1000)
+        .category(Category.BEAUTY)
+        .build();
+
+    ReflectionTestUtils.setField(product, "id", productId);
+    return product;
   }
 }


### PR DESCRIPTION
## 주요사항

- 채팅방 메시지 조회를 위한 Service, Repository 메서드를 작성하였습니다
- 해당 채팅방에 속하지 않은 사용자가 조회하면 에러를 발생시키도록 하였습니다.
- 메시지는 최신순으로 조회됩니다.

## 요청
```
GET http://localhost:8080/api/v1/chatRooms/2/messages?offset=0&limit=10
```

## 응답

```
[
    {
        "userId": 1,
        "content": "마지막 메세지",
        "createdAt": "2022-08-10T13:13:54"
    },
    {
        "userId": 3,
        "content": "거래는 어떻게 할까요??",
        "createdAt": "2022-08-10T13:13:45"
    },
    {
        "userId": 1,
        "content": "네! 개 맘에 듭니다.",
        "createdAt": "2022-08-10T13:13:34"
    },
    {
        "userId": 3,
        "content": "네 물건 좋죠?",
        "createdAt": "2022-08-10T13:13:25"
    },
    {
        "userId": 1,
        "content": "안녕하세요",
        "createdAt": "2022-08-10T13:13:14"
    },
    {
        "userId": 3,
        "content": "안녕하세요",
        "createdAt": "2022-08-10T13:13:13"
    }
]
```

## POSTMAN

<img width="915" alt="image" src="https://user-images.githubusercontent.com/28651727/184356161-d56e9902-9bcc-46f5-ae72-2b5682aac131.png">

## 쿼리

```
    select
        chatmessag0_.id as id1_1_,
        chatmessag0_.created_at as created_2_1_,
        chatmessag0_.updated_at as updated_3_1_,
        chatmessag0_.chat_room_id as chat_roo5_1_,
        chatmessag0_.message as message4_1_,
        chatmessag0_.`sender_id` as sender_i6_1_ 
    from
        chat_message chatmessag0_ 
    inner join
        chat_room chatroom1_ 
            on chatmessag0_.chat_room_id=chatroom1_.id 
    where
        chatmessag0_.chat_room_id=? 
    order by
        chatmessag0_.created_at desc limit ?
```
