### PR TITLE
[BM-336] :sparkles: 댓글 전체 조회 응답에 댓글 아이디 추가

### DIFF
--- a/src/main/java/com/saiko/bidmarket/comment/controller/dto/CommentSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/comment/controller/dto/CommentSelectResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public class CommentSelectResponse {
+  private final long commentId;
   private final long userId;
   private final String username;
   private final String profileImage;
@@ -21,6 +22,7 @@ public class CommentSelectResponse {
   public static CommentSelectResponse from(Comment comment) {
     return CommentSelectResponse
         .builder()
+        .commentId(comment.getId())
         .userId(comment
                     .getWriter()
                     .getId())

--- a/src/test/java/com/saiko/bidmarket/comment/controller/CommentApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/comment/controller/CommentApiControllerTest.java
@@ -227,6 +227,9 @@ class CommentApiControllerTest extends ControllerSetUp {
                                     .optional()
                             ),
                             responseFields(
+                                fieldWithPath("[].commentId")
+                                    .type(JsonFieldType.NUMBER)
+                                    .description("댓글 식별자"),
                                 fieldWithPath("[].userId")
                                     .type(JsonFieldType.NUMBER)
                                     .description("유저 식별자"),


### PR DESCRIPTION
* 댓글 신고를 위해 댓글 전체 조회 응답에 댓글 아이디를 추가했습니다.
* postman 테스트
<img width="1011" alt="스크린샷 2022-08-13 오전 11 23 30" src="https://user-images.githubusercontent.com/60775067/184474421-7bea3808-b675-4fa5-969d-616ebef4adfd.png">
