### PR TITLE
[BM-345] 채팅 메시지 관련 응답필드 변경

### DIFF
--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatMessageSelectResponse.java
@@ -3,6 +3,7 @@ package com.saiko.bidmarket.chat.controller.dto;
 import java.time.LocalDateTime;
 
 import com.saiko.bidmarket.chat.entity.ChatMessage;
+import com.saiko.bidmarket.user.entity.User;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,17 +13,18 @@ import lombok.Getter;
 @Builder(access = AccessLevel.PRIVATE)
 public class ChatMessageSelectResponse {
 
-  private final long userId;
+  private final ChatUserInfo userInfo;
   private final String content;
   private final LocalDateTime createdAt;
 
   public static ChatMessageSelectResponse from(ChatMessage chatMessage) {
+    User sender = chatMessage.getSender();
+
     return ChatMessageSelectResponse
         .builder()
-        .userId(chatMessage.getSender().getId())
+        .userInfo(ChatUserInfo.from(sender))
         .content(chatMessage.getMessage())
         .createdAt(chatMessage.getCreatedAt())
         .build();
   }
-
 }

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatPublishMessage.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatPublishMessage.java
@@ -6,32 +6,28 @@ import org.springframework.util.Assert;
 
 import com.saiko.bidmarket.chat.entity.ChatMessage;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Jacksonized
 public class ChatPublishMessage {
 
-  private long userId;
-
-  private String content;
-
-  private LocalDateTime createdAt;
+  private final ChatUserInfo chatUserInfo;
+  private final String content;
+  private final LocalDateTime createdAt;
 
   public static ChatPublishMessage of(ChatMessage chatMessage) {
     Assert.notNull(chatMessage, "ChatMessage must be provided");
 
-    return ChatPublishMessage.builder()
-                             .userId(chatMessage.getSender().getId())
-                             .content(chatMessage.getMessage())
-                             .createdAt(chatMessage.getCreatedAt())
-                             .build();
+    ChatUserInfo chatUserInfo = ChatUserInfo.from(chatMessage.getSender());
+    return ChatPublishMessage
+        .builder()
+        .chatUserInfo(chatUserInfo)
+        .content(chatMessage.getMessage())
+        .createdAt(chatMessage.getCreatedAt())
+        .build();
   }
 }
-

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatUserInfo.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatUserInfo.java
@@ -1,0 +1,26 @@
+package com.saiko.bidmarket.chat.controller.dto;
+
+import com.saiko.bidmarket.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+class ChatUserInfo {
+
+  private final long userId;
+  private final String username;
+  private final String profileImage;
+
+  public static ChatUserInfo from(User user) {
+    return ChatUserInfo
+        .builder()
+        .userId(user.getId())
+        .username(user.getUsername())
+        .profileImage(user.getProfileImage())
+        .build();
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatUserInfo.java
+++ b/src/main/java/com/saiko/bidmarket/chat/controller/dto/ChatUserInfo.java
@@ -9,7 +9,7 @@ import lombok.extern.jackson.Jacksonized;
 @Getter
 @Builder
 @Jacksonized
-class ChatUserInfo {
+public class ChatUserInfo {
 
   private final long userId;
   private final String username;

--- a/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepositoryImpl.java
+++ b/src/main/java/com/saiko/bidmarket/chat/repository/ChatMessageCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.saiko.bidmarket.chat.repository;
 
 import static com.saiko.bidmarket.chat.entity.QChatMessage.*;
 import static com.saiko.bidmarket.chat.entity.QChatRoom.*;
+import static com.saiko.bidmarket.user.entity.QUser.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +41,8 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
     return jpaQueryFactory
         .selectFrom(chatMessage)
         .join(chatMessage.chatRoom, chatRoom)
+        .join(chatMessage.sender, user)
+        .fetchJoin()
         .where(chatMessage.chatRoom.id.eq(chatRoomId))
         .orderBy(chatMessage.createdAt.desc())
         .offset(request.getOffset())

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatMessageApiControllerTest.java
@@ -92,9 +92,15 @@ class ChatMessageApiControllerTest extends ControllerSetUp {
                     parameterWithName("limit").description("메시지 조회 개수")
                 ),
                 responseFields(
-                    fieldWithPath("[].userId")
+                    fieldWithPath("[].userInfo.userId")
                         .type(JsonFieldType.NUMBER)
                         .description("유저 번호"),
+                    fieldWithPath("[].userInfo.username")
+                        .type(JsonFieldType.STRING)
+                        .description("유저 닉네임"),
+                    fieldWithPath("[].userInfo.profileImage")
+                        .type(JsonFieldType.STRING)
+                        .description("유저 프로필 이미지"),
                     fieldWithPath("[].content")
                         .type(JsonFieldType.STRING)
                         .description("채팅 내용"),

--- a/src/test/java/com/saiko/bidmarket/chat/controller/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/controller/ChatWebSocketControllerTest.java
@@ -44,6 +44,7 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import com.saiko.bidmarket.chat.controller.dto.ChatPublishMessage;
 import com.saiko.bidmarket.chat.controller.dto.ChatSendMessage;
+import com.saiko.bidmarket.chat.controller.dto.ChatUserInfo;
 import com.saiko.bidmarket.chat.entity.ChatMessage;
 import com.saiko.bidmarket.chat.entity.ChatRoom;
 import com.saiko.bidmarket.chat.service.ChatMessageService;
@@ -173,6 +174,7 @@ class ChatWebSocketControllerTest {
         //then
         ChatPublishMessage publishMessage = (ChatPublishMessage)blockingQueue.poll(10, SECONDS);
         assertNotNull(publishMessage);
+        assertNotNull(publishMessage.getChatUserInfo());
       }
     }
 

--- a/src/test/java/com/saiko/bidmarket/chat/service/DefaultChatMessageServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/chat/service/DefaultChatMessageServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectRequest;
 import com.saiko.bidmarket.chat.controller.dto.ChatMessageSelectResponse;
@@ -82,7 +83,8 @@ class DefaultChatMessageServiceTest {
         String content = "Test content";
 
         ChatSendMessage chatSendMessage = new ChatSendMessage(seller.getId(), content);
-        ChatMessageCreateParam createParam = ChatMessageCreateParam.of(chatRoom.getId(), chatSendMessage);
+        ChatMessageCreateParam createParam =
+            ChatMessageCreateParam.of(chatRoom.getId(), chatSendMessage);
 
         given(chatRoomRepository.findById(anyLong()))
             .willReturn(Optional.of(chatRoom));
@@ -93,12 +95,11 @@ class DefaultChatMessageServiceTest {
         given(chatMessageRepository.save(any(ChatMessage.class)))
             .willAnswer(methodInvocationMock -> methodInvocationMock.getArguments()[0]);
 
-
         //when
         ChatPublishMessage chatPublishMessage = defaultChatMessageService.create(createParam);
 
         //then
-        assertThat(chatPublishMessage.getContent()).isEqualTo(content);
+        assertThat(chatPublishMessage).isNotNull();
       }
     }
 


### PR DESCRIPTION
## 주요사항

- 프론트 요청에 따라 채팅 메시지를 보낸 사용자에 대한 정보를 구체화하였습니다.
- 웹소켓응답, HTTP API 응답 두가지에 같은 변경사항을 적용하였습니다.

## 응답 변경

### http
```
[ {
  "userInfo" : {
    "userId" : 1,
    "username" : "test",
    "profileImage" : "test"
  },
  "content" : "test",
  "createdAt" : "2022-08-13T21:19:21.166962"
} ]
```

### websocket
```
{
  "userInfo" : {
    "userId" : 1,
    "username" : "test",
    "profileImage" : "test"
  },
  "content" : "test",
  "createdAt" : "2022-08-13T21:19:21.166962"
}

```
## POST MAN

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/28651727/184496830-bb9b06ba-def9-4667-97a7-51560c0f846c.png">
