### PR TITLE
[BM-349] 상품 찜여부 api 구현 컨트롤러 + 서비스

### DIFF
--- a/src/main/java/com/saiko/bidmarket/heart/repository/HeartRepository.java
+++ b/src/main/java/com/saiko/bidmarket/heart/repository/HeartRepository.java
@@ -10,4 +10,6 @@ import com.saiko.bidmarket.user.entity.User;
 
 public interface HeartRepository extends HeartCustomRepository, JpaRepository<Heart, Long> {
   Optional<Heart> findByUserAndProduct(User user, Product product);
+
+  Optional<Heart> findByUserIdAndProductId(long userId, long productId);
 }

--- a/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/UserApiController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.saiko.bidmarket.common.jwt.JwtAuthentication;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectResponse;
+import com.saiko.bidmarket.user.controller.dto.UserHeartCheckResponse;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
@@ -111,5 +113,18 @@ public class UserApiController {
   ) {
     long userId = authentication.getUserId();
     return userService.findAllUserHearts(userId, request);
+  }
+
+  @GetMapping("{productId}/hearts")
+  public UserHeartCheckResponse isUserHearts(
+      @AuthenticationPrincipal
+      JwtAuthentication authentication,
+      @PathVariable
+      long productId
+  ) {
+    return userService.isUserHearts(
+        authentication.getUserId(),
+        productId
+    );
   }
 }

--- a/src/main/java/com/saiko/bidmarket/user/controller/dto/UserHeartCheckResponse.java
+++ b/src/main/java/com/saiko/bidmarket/user/controller/dto/UserHeartCheckResponse.java
@@ -1,0 +1,15 @@
+package com.saiko.bidmarket.user.controller.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserHeartCheckResponse {
+
+  private final boolean heart;
+
+  public static UserHeartCheckResponse from(boolean actived) {
+    return new UserHeartCheckResponse(actived);
+  }
+}

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -187,7 +187,8 @@ public class DefaultUserService implements UserService {
         .findById(productId)
         .orElseThrow(() -> new NotFoundException("Product does not exist"));
 
-    return heartRepository.findByUserIdAndProductId(userId, productId)
+    return heartRepository
+        .findByUserIdAndProductId(userId, productId)
         .map(Heart::isActived)
         .map(UserHeartCheckResponse::from)
         .orElseGet(() -> UserHeartCheckResponse.from(false));

--- a/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/DefaultUserService.java
@@ -20,6 +20,7 @@ import com.saiko.bidmarket.product.repository.ProductRepository;
 import com.saiko.bidmarket.product.repository.dto.UserProductSelectQueryParameter;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectResponse;
+import com.saiko.bidmarket.user.controller.dto.UserHeartCheckResponse;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
@@ -174,6 +175,22 @@ public class DefaultUserService implements UserService {
                             .map(Heart::getProduct)
                             .map(UserHeartSelectResponse::from)
                             .collect(Collectors.toList());
+  }
+
+  @Override
+  public UserHeartCheckResponse isUserHearts(
+      long userId,
+      long productId
+  ) {
+
+    productRepository
+        .findById(productId)
+        .orElseThrow(() -> new NotFoundException("Product does not exist"));
+
+    return heartRepository.findByUserIdAndProductId(userId, productId)
+        .map(Heart::isActived)
+        .map(UserHeartCheckResponse::from)
+        .orElseGet(() -> UserHeartCheckResponse.from(false));
   }
 
   private Heart findHeart(

--- a/src/main/java/com/saiko/bidmarket/user/service/UserService.java
+++ b/src/main/java/com/saiko/bidmarket/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectResponse;
+import com.saiko.bidmarket.user.controller.dto.UserHeartCheckResponse;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
@@ -40,4 +41,6 @@ public interface UserService {
       long userId,
       UserHeartSelectRequest request
   );
+
+  UserHeartCheckResponse isUserHearts(long userId, long productId);
 }

--- a/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/controller/UserApiControllerTest.java
@@ -33,6 +33,7 @@ import com.saiko.bidmarket.common.Sort;
 import com.saiko.bidmarket.product.entity.Product;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserBiddingSelectResponse;
+import com.saiko.bidmarket.user.controller.dto.UserHeartCheckResponse;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectRequest;
 import com.saiko.bidmarket.user.controller.dto.UserHeartSelectResponse;
 import com.saiko.bidmarket.user.controller.dto.UserProductSelectRequest;
@@ -849,6 +850,72 @@ class UserApiControllerTest extends ControllerSetUp {
 
         // then
         response.andExpect(status().isBadRequest());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("isUserHeart 메서드는")
+  @WithMockCustomLoginUser
+  class DescribeIsUserHeart {
+
+    @Nested
+    @DisplayName("유효한 값을 받아 호출되면")
+    class ContextValidCall {
+
+      @Test
+      @DisplayName("200 ok와 서비스 isUaerHeart 메서드를 호출한다.")
+      void itCallServiceIsUserHeart() throws Exception {
+        //given
+        final long productId = 1;
+        final UserHeartCheckResponse responseDto = new UserHeartCheckResponse(true);
+
+        when(userService.isUserHearts(anyLong(), anyLong())).thenReturn(responseDto);
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(BASE_URL + "/" + productId + "/hearts");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(userService).isUserHearts(anyLong(), anyLong());
+        response
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "isUserHeart",
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("heart")
+                            .type(JsonFieldType.BOOLEAN)
+                            .description("유저 찜 여부")
+                    )
+                )
+            );
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 상품 id를 받으면")
+    class ContextNotExistProductId {
+
+      @Test
+      @DisplayName("NotFound Exception을 반환한다.")
+      void itThrowNotFoundException() throws Exception {
+        //given
+        final long productId = 1;
+
+        when(userService.isUserHearts(anyLong(), anyLong())).thenThrow(NotFoundException.class);
+        //when
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+            .get(BASE_URL + "/" + productId + "/hearts");
+
+        ResultActions response = mockMvc.perform(request);
+
+        //then
+        verify(userService).isUserHearts(anyLong(), anyLong());
+        response
+            .andExpect(status().isNotFound());
       }
     }
   }

--- a/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/saiko/bidmarket/user/service/DefaultUserServiceTest.java
@@ -878,14 +878,16 @@ class DefaultUserServiceTest {
         //given
         final long userId = 1;
         final long productId = 1;
-        final User user = User.builder()
+        final User user = User
+            .builder()
             .username("test")
             .group(new Group())
             .providerId("test")
             .provider("test")
             .profileImage("t")
             .build();
-        final Product product = Product.builder()
+        final Product product = Product
+            .builder()
             .title("test")
             .writer(user)
             .description("test")
@@ -905,7 +907,9 @@ class DefaultUserServiceTest {
         UserHeartCheckResponse response = defaultUserService.isUserHearts(userId, productId);
 
         //then
-        Assertions.assertThat(response.isHeart()).isTrue();
+        Assertions
+            .assertThat(response.isHeart())
+            .isTrue();
       }
     }
 
@@ -919,21 +923,23 @@ class DefaultUserServiceTest {
         //given
         final long userId = 1;
         final long productId = 1;
-        final User user = User.builder()
-                              .username("test")
-                              .group(new Group())
-                              .providerId("test")
-                              .provider("test")
-                              .profileImage("t")
-                              .build();
-        final Product product = Product.builder()
-                                       .title("test")
-                                       .writer(user)
-                                       .description("test")
-                                       .minimumPrice(10000)
-                                       .category(BOOK_TICKET_RECORD)
-                                       .location("test")
-                                       .build();
+        final User user = User
+            .builder()
+            .username("test")
+            .group(new Group())
+            .providerId("test")
+            .provider("test")
+            .profileImage("t")
+            .build();
+        final Product product = Product
+            .builder()
+            .title("test")
+            .writer(user)
+            .description("test")
+            .minimumPrice(10000)
+            .category(BOOK_TICKET_RECORD)
+            .location("test")
+            .build();
         final Heart heart = Heart.of(user, product);
 
         when(productRepository.findById(anyLong()))
@@ -945,7 +951,9 @@ class DefaultUserServiceTest {
         UserHeartCheckResponse response = defaultUserService.isUserHearts(userId, productId);
 
         //then
-        Assertions.assertThat(response.isHeart()).isFalse();
+        Assertions
+            .assertThat(response.isHeart())
+            .isFalse();
       }
     }
   }


### PR DESCRIPTION
- 유저가 헤딩 싱픔에 찜했는지 확인하는 api입니다.
- 상품 상세정보에 응답필드 추가보다 api 하나 파는게 구현상 더 쉬울것같다고 해서 구현했습니다.
- 사진에 Request Body는 무시해도됩니다
<img width="543" alt="image" src="https://user-images.githubusercontent.com/57293011/184532672-5e5269d8-7a61-4178-be1c-c2a80cfd9ef2.png">
